### PR TITLE
[#13] feat(theme): add useTheme hook & setup lucide-react + import-x

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,12 +109,9 @@ export default [
       "import-x/order": [
         "error",
         {
-          groups: ["builtin", "external", "internal", ["parent", "sibling", "index"], "type"],
+          groups: ["builtin", "external", "internal", ["parent", "sibling", "index"]],
           "newlines-between": "always",
-          alphabetize: {
-            order: "asc",
-            caseInsensitive: true,
-          },
+          alphabetize: { order: "asc", caseInsensitive: true },
           pathGroups: [
             { pattern: "react", group: "external", position: "before" },
             { pattern: "react-dom", group: "external", position: "before" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,10 +9,10 @@ import path from "node:path";
 
 import { includeIgnoreFile } from "@eslint/compat";
 import js from "@eslint/js";
+import pluginQuery from "@tanstack/eslint-plugin-query";
 import { configs, plugins } from "eslint-config-airbnb-extended";
 import { rules as prettierConfigRules } from "eslint-config-prettier";
 import prettierPlugin from "eslint-plugin-prettier";
-import pluginQuery from "@tanstack/eslint-plugin-query";
 
 const gitignorePath = path.resolve(".", ".gitignore");
 
@@ -102,6 +102,27 @@ export default [
       "react/jsx-uses-react": "off",
       "import-x/extensions": "off",
       "import-x/prefer-default-export": "off",
+      "import-x/first": "error",
+      "import-x/no-duplicates": "error",
+      "import-x/newline-after-import": ["error", { count: 1 }],
+
+      "import-x/order": [
+        "error",
+        {
+          groups: ["builtin", "external", "internal", ["parent", "sibling", "index"], "type"],
+          "newlines-between": "always",
+          alphabetize: {
+            order: "asc",
+            caseInsensitive: true,
+          },
+          pathGroups: [
+            { pattern: "react", group: "external", position: "before" },
+            { pattern: "react-dom", group: "external", position: "before" },
+            { pattern: "@/**", group: "internal", position: "before" },
+          ],
+          warnOnUnassignedImports: true,
+        },
+      ],
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.90.6",
         "class-variance-authority": "^0.7.1",
+        "lucide-react": "^0.552.0",
         "motion": "^12.23.24",
         "react": "19.2.0",
         "react-dom": "19.2.0",
@@ -6007,6 +6008,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.552.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.552.0.tgz",
+      "integrity": "sha512-g9WCjmfwqbexSnZE+2cl21PCfXOcqnGeWeMTNAOGEfpPbm/ZF4YIq77Z8qWrxbu660EKuLB4nSLggoKnCb+isw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.90.6",
     "class-variance-authority": "^0.7.1",
+    "lucide-react": "^0.552.0",
     "motion": "^12.23.24",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
+
 import { button, type ButtonVariantProps } from "./variants";
 
 type ButtonState = "neutral" | "pressed" | "focus" | "inactive";

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -6,16 +6,22 @@ export default function useTheme() {
   const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
-    let userTheme = localStorage.getItem("theme");
+    const storedTheme = localStorage.getItem("theme");
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
-    if (!userTheme) {
-      userTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    if (storedTheme === "light" || storedTheme === "dark") {
+      setTheme(storedTheme);
+    } else {
+      setTheme(mediaQuery.matches ? "dark" : "light");
     }
 
-    if (userTheme === "light" || userTheme === "dark") {
-      localStorage.setItem("theme", userTheme);
-      setTheme(userTheme);
-    }
+    const handleMediaQueryChange = (e: MediaQueryListEvent) => {
+      setTheme(e.matches ? "dark" : "light");
+    };
+
+    mediaQuery.addEventListener("change", handleMediaQueryChange);
+
+    return () => mediaQuery.removeEventListener("change", handleMediaQueryChange);
   }, []);
 
   useEffect(() => {

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+export default function useTheme() {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    let userTheme = localStorage.getItem("theme");
+
+    if (!userTheme) {
+      userTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+
+    if (userTheme === "light" || userTheme === "dark") {
+      localStorage.setItem("theme", userTheme);
+      setTheme(userTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return { theme, setTheme };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@/styles/globals.css";
+
 import App from "@/App";
+import "@/styles/globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "@/styles/fonts.css";
+@import "../styles/fonts.css";
 
 :root {
   --font-galmuri: "Galmuri9";
@@ -24,6 +24,7 @@
     inset -1.5px -1.5px 0 0 var(--color-bevel-top-o), inset 3px 3px 0 0 var(--color-bevel-btm-i),
     inset -3px -3px 0 0 var(--color-bevel-top-i);
 }
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @layer theme {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,11 +1,11 @@
 @import "tailwindcss";
-@import "../styles/fonts.css";
+@import "./fonts.css";
 
-:root {
-  --font-galmuri: "Galmuri9";
-}
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
+  --font-galmuri: "Galmuri9";
+
   --color-bevel-top-o: #f9fafb; /* 1 1 */
   --color-bevel-top-i: #f9f4ff; /* 2 2 */
   --color-surface: #f0eaff;
@@ -24,8 +24,6 @@
     inset -1.5px -1.5px 0 0 var(--color-bevel-top-o), inset 3px 3px 0 0 var(--color-bevel-btm-i),
     inset -3px -3px 0 0 var(--color-bevel-top-i);
 }
-
-@custom-variant dark (&:where(.dark, .dark *));
 
 @layer theme {
   :root {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,5 +1,5 @@
-/* eslint-disable */
-// supabase 자동 생성 types 파일인데 린트에러가 잡히네요 린트 무시 걸어두겠습니다.
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style */
 
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+
 import type { Database } from "@/types/database.types";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-underscore-dangle */
 
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
-import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## 📖 개요

- 다크/라이트 테마 전환용 useTheme 커스텀 훅 추가
- lucide-react 패키지 추가
- eslint-plugin-import-x 설정 추가로 import 정렬 자동화

## ✅ 관련 이슈

- Close #13 

## 🛠️ 상세 작업 내용

- [x] useTheme 훅 구현 (localStorage + prefers-color-scheme 기반)
- [x] lucide-react 설치
- [x] eslint-plugin-import-x 설정으로 import 자동 정렬 적용

## ⚠️ 주의 사항

import 자동 수정을 원하시면 VSCode `settings.json` 파일에 아래 코드를 추가해주시면 됩니다.
다른 부분까지 자동 수정될 수 있는 점 주의 부탁드립니다.

```json
{
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": "explicit"
  },
  "eslint.validate": [
    "javascript",
    "javascriptreact",
    "typescript",
    "typescriptreact"
  ]
}
 ```

## 👥 리뷰 확인 사항

패키지 설치, ESLint 설정 변경 꼭 확인 부탁드려요 🙏
