### PR TITLE
[#23] style(theme): refactor dark variant, add accent/disabled utilities, and split utility files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,3 @@
-/**
- * THIS FILE WAS AUTO-GENERATED.
- * PLEASE DO NOT EDIT IT MANUALLY.
- * ===============================
- * IF YOU'RE COPYING THIS INTO AN ESLINT CONFIG, REMOVE THIS COMMENT BLOCK.
- */
-
 import path from "node:path";
 
 import { includeIgnoreFile } from "@eslint/compat";
@@ -100,6 +93,7 @@ export default [
     rules: {
       "react/react-in-jsx-scope": "off",
       "react/jsx-uses-react": "off",
+      "react/require-default-props": "off",
       "import-x/extensions": "off",
       "import-x/prefer-default-export": "off",
       "import-x/first": "error",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./fonts.css";
+@import "./utilities.css";
 
 @theme {
   --font-galmuri: "Galmuri9";
@@ -30,33 +31,6 @@
   --color-bevel-light-inner: #5a5e8a;
   --color-bevel-shadow-inner: #2a2d47;
   --color-bevel-shadow-outer: #141628;
-}
-
-@utility bevel-default {
-  background: var(--color-surface);
-  box-shadow:
-    inset -1.5px -1.5px 0 0 var(--color-bevel-shadow-outer),
-    inset 1.5px 1.5px 0 0 var(--color-bevel-light-outer),
-    inset -3px -3px 0 0 var(--color-bevel-shadow-inner),
-    inset 3px 3px 0 0 var(--color-bevel-light-inner);
-}
-
-@utility bevel-pressed {
-  background: var(--color-surface);
-  box-shadow:
-    inset 1.5px 1.5px 0 0 var(--color-bevel-shadow-outer),
-    inset -1.5px -1.5px 0 0 var(--color-bevel-light-outer),
-    inset 3px 3px 0 0 var(--color-bevel-shadow-inner),
-    inset -3px -3px 0 0 var(--color-bevel-light-inner);
-}
-
-@utility accent-gradient {
-  background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent-end) 100%);
-}
-
-@utility disabled-base {
-  opacity: var(--opacity-disabled);
-  cursor: not-allowed;
 }
 
 html,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,54 +1,62 @@
 @import "tailwindcss";
 @import "./fonts.css";
 
-@custom-variant dark (&:where(.dark, .dark *));
-
 @theme {
   --font-galmuri: "Galmuri9";
 
-  --color-bevel-top-o: #f9fafb; /* 1 1 */
-  --color-bevel-top-i: #f9f4ff; /* 2 2 */
-  --color-surface: #f0eaff;
-  --color-bevel-btm-i: #a199c5; /* -2 -2 */
-  --color-bevel-btm-o: #6b5f8a; /* -1 -1 */
-
   --color-text-default: #2d2640;
+  --color-error: #c93636;
+  --opacity-disabled: 0.5;
 
-  --shadow-bevel-default:
-    inset -1.5px -1.5px 0 0 var(--color-bevel-btm-o),
-    inset 1.5px 1.5px 0 0 var(--color-bevel-top-o), inset -3px -3px 0 0 var(--color-bevel-btm-i),
-    inset 3px 3px 0 0 var(--color-bevel-top-i);
+  --color-accent: #b2aaeb;
+  --color-accent-end: #aac1f8;
+  --color-accent-contrast: #fcfcfd;
 
-  --shadow-bevel-pressed:
-    inset 1.5px 1.5px 0 0 var(--color-bevel-btm-o),
-    inset -1.5px -1.5px 0 0 var(--color-bevel-top-o), inset 3px 3px 0 0 var(--color-bevel-btm-i),
-    inset -3px -3px 0 0 var(--color-bevel-top-i);
+  --color-surface: #e9e6fd;
+
+  --color-bevel-light-outer: #f8f6ff;
+  --color-bevel-light-inner: #f2f1ff;
+  --color-bevel-shadow-inner: #a199c5;
+  --color-bevel-shadow-outer: #6b5f8a;
 }
 
-@layer theme {
-  :root {
-    @variant dark {
-      --color-bevel-top-o: #9ba0d0;
-      --color-bevel-top-i: #53567a;
-      --color-surface: #3a3d5a;
-      --color-bevel-btm-i: #252840;
-      --color-bevel-btm-o: #1a1c2e;
+.dark {
+  --color-text-default: #eae9ff;
+  --opacity-disabled: 0.55;
 
-      --color-text-default: #eae9ff;
-    }
-  }
+  --color-surface: #3a3d5a;
+
+  --color-bevel-light-outer: #8388b5;
+  --color-bevel-light-inner: #5a5e8a;
+  --color-bevel-shadow-inner: #2a2d47;
+  --color-bevel-shadow-outer: #141628;
 }
 
-@layer utilities {
-  .bevel-default {
-    background: var(--color-surface);
-    box-shadow: var(--shadow-bevel-default);
-  }
+@utility bevel-default {
+  background: var(--color-surface);
+  box-shadow:
+    inset -1.5px -1.5px 0 0 var(--color-bevel-shadow-outer),
+    inset 1.5px 1.5px 0 0 var(--color-bevel-light-outer),
+    inset -3px -3px 0 0 var(--color-bevel-shadow-inner),
+    inset 3px 3px 0 0 var(--color-bevel-light-inner);
+}
 
-  .bevel-pressed {
-    background: var(--color-surface);
-    box-shadow: var(--shadow-bevel-pressed);
-  }
+@utility bevel-pressed {
+  background: var(--color-surface);
+  box-shadow:
+    inset 1.5px 1.5px 0 0 var(--color-bevel-shadow-outer),
+    inset -1.5px -1.5px 0 0 var(--color-bevel-light-outer),
+    inset 3px 3px 0 0 var(--color-bevel-shadow-inner),
+    inset -3px -3px 0 0 var(--color-bevel-light-inner);
+}
+
+@utility accent-gradient {
+  background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent-end) 100%);
+}
+
+@utility disabled-base {
+  opacity: var(--opacity-disabled);
+  cursor: not-allowed;
 }
 
 html,

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,0 +1,26 @@
+@utility bevel-default {
+  background: var(--color-surface);
+  box-shadow:
+    inset -1.5px -1.5px 0 0 var(--color-bevel-shadow-outer),
+    inset 1.5px 1.5px 0 0 var(--color-bevel-light-outer),
+    inset -3px -3px 0 0 var(--color-bevel-shadow-inner),
+    inset 3px 3px 0 0 var(--color-bevel-light-inner);
+}
+
+@utility bevel-pressed {
+  background: var(--color-surface);
+  box-shadow:
+    inset 1.5px 1.5px 0 0 var(--color-bevel-shadow-outer),
+    inset -1.5px -1.5px 0 0 var(--color-bevel-light-outer),
+    inset 3px 3px 0 0 var(--color-bevel-shadow-inner),
+    inset -3px -3px 0 0 var(--color-bevel-light-inner);
+}
+
+@utility accent-gradient {
+  background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent-end) 100%);
+}
+
+@utility disabled-base {
+  opacity: var(--opacity-disabled);
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## 📖 개요

- 다크 테마 variant 문법을 `.dark` 클래스로 변경  
- 악센트 컬러 및 그라디언트 유틸리티 추가  
- disabled 관련 opacity 토큰 및 유틸리티 추가  
- `@layer utilities` 구문을 최신 `@utility` 문법으로 마이그레이션  
- 유틸리티 정의를 별도 파일로 분리하여 구조 개선

## ✅ 관련 이슈

- Close #23 

## 🛠️ 상세 작업 내용

- [x] `@custom-variant dark` → `.dark` 변환
- [x] accent 색상 및 gradient 유틸리티 추가
- [x] disabled opacity theme 토큰 추가
- [x] `@layer utilities` → `@utility`로 마이그레이션
- [x] 유틸리티 정의 파일 분리

## 👥 리뷰 확인 사항

추가된 토큰 및 유틸리티 확인 부탁드립니다.
`disabled-base`의 경우 `disabled:disabled-base` 방식으로 사용하도록 구현했습니다.
disabled은 브라우저가 포인터 이벤트를 자동으로 차단해서 포인터 이벤트 차단 코드는 작성하지 않았습니다.
`a` 같이 disabled가 통하지 않는 곳은 별도 처리 필요합니다.
