### PR TITLE
[#27] feat(scrollbar): 커스텀 스크롤바 구현

### DIFF
--- a/src/assets/icons/scrollbar-arrow-down.svg
+++ b/src/assets/icons/scrollbar-arrow-down.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -0.5 16 16" shape-rendering="crispEdges">
+<metadata>Made with Pixels to Svg https://codepen.io/shshaw/pen/XbxvNj</metadata>
+<path stroke="#000000" d="M4 5h7M5 6h5M6 7h3M7 8h1" />
+</svg>

--- a/src/assets/icons/scrollbar-arrow-left.svg
+++ b/src/assets/icons/scrollbar-arrow-left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -0.5 16 16" shape-rendering="crispEdges">
+<metadata>Made with Pixels to Svg https://codepen.io/shshaw/pen/XbxvNj</metadata>
+<path stroke="#000000" d="M8 3h1M7 4h2M6 5h3M5 6h4M6 7h3M7 8h2M8 9h1" />
+</svg>

--- a/src/assets/icons/scrollbar-arrow-right.svg
+++ b/src/assets/icons/scrollbar-arrow-right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -0.5 16 16" shape-rendering="crispEdges">
+<metadata>Made with Pixels to Svg https://codepen.io/shshaw/pen/XbxvNj</metadata>
+<path stroke="#000000" d="M6 3h1M6 4h2M6 5h3M6 6h4M6 7h3M6 8h2M6 9h1" />
+</svg>

--- a/src/assets/icons/scrollbar-arrow-up.svg
+++ b/src/assets/icons/scrollbar-arrow-up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -0.5 16 16" shape-rendering="crispEdges">
+<metadata>Made with Pixels to Svg https://codepen.io/shshaw/pen/XbxvNj</metadata>
+<path stroke="#000000" d="M7 5h1M6 6h3M5 7h5M4 8h7" />
+</svg>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./fonts.css";
 @import "./utilities.css";
+@import "./scrollbar.css";
 
 @theme {
   --font-galmuri: "Galmuri9";
@@ -53,70 +54,4 @@ body {
   body {
     font-size: 15px;
   }
-}
-
-/* 스크롤바 기본 설정 */
-body *::-webkit-scrollbar {
-  background: none;
-}
-
-/* 썸 (Thumb): bevel-default 효과 */
-body *::-webkit-scrollbar-thumb {
-  @apply bevel-default;
-  border: none;
-}
-
-body *::-webkit-scrollbar-thumb:active {
-  @apply bevel-pressed;
-}
-
-/* 트랙 (Track): bevel-pressed 효과 */
-body *::-webkit-scrollbar-track {
-  @apply bevel-pressed;
-  border: none;
-}
-
-/* 버튼 (Button): bevel-default 효과 */
-body *::-webkit-scrollbar-button {
-  @apply bevel-default;
-  border: none;
-  background-repeat: no-repeat;
-}
-
-body *::-webkit-scrollbar-button:active {
-  @apply bevel-pressed;
-}
-
-/* 버튼 화살표 아이콘 */
-body *::-webkit-scrollbar-button:single-button:vertical:decrement {
-  background-image: url("../assets/icons/scrollbar-arrow-up.svg");
-}
-
-body *::-webkit-scrollbar-button:single-button:vertical:increment {
-  background-image: url("../assets/icons/scrollbar-arrow-down.svg");
-}
-
-body *::-webkit-scrollbar-button:single-button:horizontal:decrement {
-  background-image: url("../assets/icons/scrollbar-arrow-left.svg");
-}
-
-body *::-webkit-scrollbar-button:single-button:horizontal:increment {
-  background-image: url("../assets/icons/scrollbar-arrow-right.svg");
-}
-
-/* 코너 (Corner) */
-body *::-webkit-scrollbar-corner {
-  background-color: var(--color-surface);
-}
-
-/* Disabled 스크롤바 스타일 */
-.scrollbar-disabled::-webkit-scrollbar-thumb,
-.scrollbar-disabled *::-webkit-scrollbar-thumb {
-  display: none;
-}
-
-.scrollbar-disabled::-webkit-scrollbar-track,
-.scrollbar-disabled *::-webkit-scrollbar-track {
-  box-shadow: none;
-  background-color: var(--color-bevel-light-inner);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -54,3 +54,69 @@ body {
     font-size: 15px;
   }
 }
+
+/* 스크롤바 기본 설정 */
+body *::-webkit-scrollbar {
+  background: none;
+}
+
+/* 썸 (Thumb): bevel-default 효과 */
+body *::-webkit-scrollbar-thumb {
+  @apply bevel-default;
+  border: none;
+}
+
+body *::-webkit-scrollbar-thumb:active {
+  @apply bevel-pressed;
+}
+
+/* 트랙 (Track): bevel-pressed 효과 */
+body *::-webkit-scrollbar-track {
+  @apply bevel-pressed;
+  border: none;
+}
+
+/* 버튼 (Button): bevel-default 효과 */
+body *::-webkit-scrollbar-button {
+  @apply bevel-default;
+  border: none;
+  background-repeat: no-repeat;
+}
+
+body *::-webkit-scrollbar-button:active {
+  @apply bevel-pressed;
+}
+
+/* 버튼 화살표 아이콘 */
+body *::-webkit-scrollbar-button:single-button:vertical:decrement {
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTcgNWgxTTYgNmgzTTUgN2g1TTQgOGg3IiAvPgo8L3N2Zz4=");
+}
+
+body *::-webkit-scrollbar-button:single-button:vertical:increment {
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTQgNWg3TTUgNmg1TTYgN2gzTTcgOGgxIiAvPgo8L3N2Zz4=");
+}
+
+body *::-webkit-scrollbar-button:single-button:horizontal:decrement {
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTggM2gxTTcgNGgyTTYgNWgzTTUgNmg0TTYgN2gzTTcgOGgyTTggOWgxIiAvPgo8L3N2Zz4=");
+}
+
+body *::-webkit-scrollbar-button:single-button:horizontal:increment {
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTYgM2gxTTYgNGgyTTYgNWgzTTYgNmg0TTYgN2gzTTYgOGgyTTYgOWgxIiAvPgo8L3N2Zz4=");
+}
+
+/* 코너 (Corner) */
+body *::-webkit-scrollbar-corner {
+  background-color: var(--color-surface);
+}
+
+/* Disabled 스크롤바 스타일 */
+.scrollbar-disabled::-webkit-scrollbar-thumb,
+.scrollbar-disabled *::-webkit-scrollbar-thumb {
+  display: none;
+}
+
+.scrollbar-disabled::-webkit-scrollbar-track,
+.scrollbar-disabled *::-webkit-scrollbar-track {
+  box-shadow: none;
+  background-color: var(--color-bevel-light-inner);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -89,19 +89,19 @@ body *::-webkit-scrollbar-button:active {
 
 /* 버튼 화살표 아이콘 */
 body *::-webkit-scrollbar-button:single-button:vertical:decrement {
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTcgNWgxTTYgNmgzTTUgN2g1TTQgOGg3IiAvPgo8L3N2Zz4=");
+  background-image: url("../assets/icons/scrollbar-arrow-up.svg");
 }
 
 body *::-webkit-scrollbar-button:single-button:vertical:increment {
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTQgNWg3TTUgNmg1TTYgN2gzTTcgOGgxIiAvPgo8L3N2Zz4=");
+  background-image: url("../assets/icons/scrollbar-arrow-down.svg");
 }
 
 body *::-webkit-scrollbar-button:single-button:horizontal:decrement {
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTggM2gxTTcgNGgyTTYgNWgzTTUgNmg0TTYgN2gzTTcgOGgyTTggOWgxIiAvPgo8L3N2Zz4=");
+  background-image: url("../assets/icons/scrollbar-arrow-left.svg");
 }
 
 body *::-webkit-scrollbar-button:single-button:horizontal:increment {
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTAuNSAxNiAxNiIgc2hhcGUtcmVuZGVyaW5nPSJjcmlzcEVkZ2VzIj4KPG1ldGFkYXRhPk1hZGUgd2l0aCBQaXhlbHMgdG8gU3ZnIGh0dHBzOi8vY29kZXBlbi5pby9zaHNoYXcvcGVuL1hieHZOajwvbWV0YWRhdGE+CjxwYXRoIHN0cm9rZT0iIzAwMDAwMCIgZD0iTTYgM2gxTTYgNGgyTTYgNWgzTTYgNmg0TTYgN2gzTTYgOGgyTTYgOWgxIiAvPgo8L3N2Zz4=");
+  background-image: url("../assets/icons/scrollbar-arrow-right.svg");
 }
 
 /* 코너 (Corner) */

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -1,0 +1,73 @@
+/* 스크롤바 기본 설정 */
+body *::-webkit-scrollbar {
+  width: 16px;
+  height: 16px;
+  background: none;
+}
+
+/* 스크롤바 오버레이 모드 (영역 차지하지 않음) */
+/* scrollbar-gutter: auto는 기본값으로 스크롤바가 영역을 차지하지 않도록 함 */
+body * {
+  scrollbar-gutter: auto;
+}
+
+/* 썸 (Thumb): bevel-default 효과 */
+body *::-webkit-scrollbar-thumb {
+  @apply bevel-default;
+  border: none;
+}
+
+body *::-webkit-scrollbar-thumb:active {
+  @apply bevel-pressed;
+}
+
+/* 트랙 (Track): bevel-pressed 효과 */
+body *::-webkit-scrollbar-track {
+  @apply bevel-pressed;
+  border: none;
+}
+
+/* 버튼 (Button): bevel-default 효과 */
+body *::-webkit-scrollbar-button {
+  @apply bevel-default;
+  border: none;
+  background-repeat: no-repeat;
+}
+
+body *::-webkit-scrollbar-button:active {
+  @apply bevel-pressed;
+}
+
+/* 버튼 화살표 아이콘 */
+body *::-webkit-scrollbar-button:single-button:vertical:decrement {
+  background-image: url("../assets/icons/scrollbar-arrow-up.svg");
+}
+
+body *::-webkit-scrollbar-button:single-button:vertical:increment {
+  background-image: url("../assets/icons/scrollbar-arrow-down.svg");
+}
+
+body *::-webkit-scrollbar-button:single-button:horizontal:decrement {
+  background-image: url("../assets/icons/scrollbar-arrow-left.svg");
+}
+
+body *::-webkit-scrollbar-button:single-button:horizontal:increment {
+  background-image: url("../assets/icons/scrollbar-arrow-right.svg");
+}
+
+/* 코너 (Corner) */
+body *::-webkit-scrollbar-corner {
+  background-color: var(--color-surface);
+}
+
+/* Disabled 스크롤바 스타일 */
+.scrollbar-disabled::-webkit-scrollbar-thumb,
+.scrollbar-disabled *::-webkit-scrollbar-thumb {
+  display: none;
+}
+
+.scrollbar-disabled::-webkit-scrollbar-track,
+.scrollbar-disabled *::-webkit-scrollbar-track {
+  box-shadow: none;
+  background-color: var(--color-bevel-light-inner);
+}

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -5,10 +5,10 @@ body *::-webkit-scrollbar {
   background: none;
 }
 
-/* 스크롤바 오버레이 모드 (영역 차지하지 않음) */
-/* scrollbar-gutter: auto는 기본값으로 스크롤바가 영역을 차지하지 않도록 함 */
+/* 스크롤바 gutter 설정 */
+/* stable로 스크롤바 영역을 미리 정의해 두고 both-edges로 왼쪽과 오른쪽 다 차지하도록 합니다. */
 body * {
-  scrollbar-gutter: auto;
+  scrollbar-gutter: stable both-edges;
 }
 
 /* 썸 (Thumb): bevel-default 효과 */


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 작업 내용 서술
- CSS `::-webkit-scrollbar` pseudo-element를 사용한 네이티브 스크롤바 스타일링

- disabled 상태 지원 (thumb 숨김, 트랙 bevel 효과 제거)


## ✅ 관련 이슈

- Close #27 

## 🛠️ 상세 작업 내용

- [x] CSS 커스텀 스크롤바 스타일 구현 (`globals.css`)
  - 스크롤바 기본 설정
  - Thumb: bevel-default 효과 적용
  - Track: bevel-pressed 효과 적용
  - Button: bevel-default 효과 및 화살표 아이콘 적용
  - Disabled 상태 스타일 (thumb 숨김, 트랙 bevel 제거)
- [x] SVG 아이콘 파일 추가 (`src/assets/icons/`)
  - `scrollbar-arrow-up.svg` (수직 스크롤 위쪽)
  - `scrollbar-arrow-down.svg` (수직 스크롤 아래쪽)
  - `scrollbar-arrow-left.svg` (수평 스크롤 왼쪽)
  - `scrollbar-arrow-right.svg` (수평 스크롤 오른쪽)


## ⚠️ 주의 사항 (옵션)

<!-- 다른 작업물에 영향을 줄 수 있는 변화가 있다면 적어주세요 -->
- `body *::-webkit-scrollbar` 선택자를 사용하여 내부 요소에만 적용
- 전체 페이지 스크롤바는 커스텀 스타일이 적용되지 않음
- WebKit 기반 브라우저(Chrome, Safari, Edge)에서만 동작

## 📸 스크린샷 (옵션)

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->
<img width="778" height="444" alt="image" src="https://github.com/user-attachments/assets/8b8a78f1-3292-4db5-8310-34cf7b92b544" />

## 👥 리뷰 확인 사항 (옵션)

<!-- 코드 리뷰 시에 특별히 확인해야 하는 사항이 있으면 적어주세요 -->
<!-- 예시: 제가 지정한 타입 정의가 적절한지 확인 부탁드립니다 -->

윈도우/mac 두 OS 모두 스크롤바가 영역을 차지하지 않고 떠있도록 구현하는건 찾아보겠습니다.
이후 구현하고, 푸쉬하고 다시 노티드릴게요
