### PR TITLE
[#31] feat(checkbox): 커스텀 체크박스 구현

### DIFF
--- a/src/components/CheckBox/Box.tsx
+++ b/src/components/CheckBox/Box.tsx
@@ -1,0 +1,43 @@
+import { twMerge } from "tailwind-merge";
+
+import { checkBox, type CheckBoxVariantProps } from "./variants/boxVariants";
+
+interface BoxProps extends React.ComponentPropsWithoutRef<"div">, CheckBoxVariantProps {
+  isChecked?: boolean;
+}
+
+export default function Box({
+  isChecked = false,
+  isDisabled = false,
+  className,
+  ...rest
+}: BoxProps) {
+  return (
+    <div className={twMerge(checkBox({ isDisabled }), className)} {...rest}>
+      {isChecked && (
+        <svg
+          width="10.81"
+          height="10.81"
+          viewBox="0 0 11 11"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g clipPath="url(#clip0_247_86)">
+            <path d="M0 2.8833H1.54464V7.92912H0V2.8833Z" fill="#2D2640" />
+            <path d="M1.54468 4.3252H3.08932V9.37103H1.54468V4.3252Z" fill="#2D2640" />
+            <path d="M3.08923 5.7666H4.63388V10.8124H3.08923V5.7666Z" fill="#2D2640" />
+            <path d="M4.63391 4.3252H6.17855V9.37103H4.63391V4.3252Z" fill="#2D2640" />
+            <path d="M6.17859 2.8833H7.72323V7.92912H6.17859V2.8833Z" fill="#2D2640" />
+            <path d="M7.72327 1.44189H9.26791V6.48773H7.72327V1.44189Z" fill="#2D2640" />
+            <path d="M9.26782 0H10.8125V5.04584H9.26782V0Z" fill="#2D2640" />
+          </g>
+          <defs>
+            <clipPath id="clip0_247_86">
+              <rect width="10.8125" height="10.8125" fill="white" />
+            </clipPath>
+          </defs>
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/src/components/CheckBox/CheckBox.test.tsx
+++ b/src/components/CheckBox/CheckBox.test.tsx
@@ -1,0 +1,236 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState, type ChangeEvent } from "react";
+import { describe, test, expect } from "vitest";
+
+import Input from "../Input/Input";
+
+describe("Input", () => {
+  describe("렌더링", () => {
+    test("기본 인풋이 렌더링 된다", () => {
+      render(<Input placeholder="텍스트 입력" />);
+      expect(screen.getByPlaceholderText("텍스트 입력")).toBeInTheDocument();
+    });
+
+    test("placeholder 없이도 렌더링 된다", () => {
+      render(<Input />);
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+  });
+
+  describe("입력 동작", () => {
+    test("텍스트를 입력할 수 있다", async () => {
+      const user = userEvent.setup();
+      render(<Input placeholder="이름" />);
+
+      const input = screen.getByPlaceholderText("이름");
+      await user.type(input, "John Doe");
+
+      expect(input).toHaveValue("John Doe");
+    });
+
+    test("초기값이 설정된다", () => {
+      render(<Input defaultValue="기본값" />);
+
+      expect(screen.getByDisplayValue("기본값")).toBeInTheDocument();
+    });
+
+    test("제어 컴포넌트로 동작한다", async () => {
+      const user = userEvent.setup();
+
+      function TestComponent() {
+        const [value, setValue] = useState<string>("");
+
+        const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+          setValue(e.target.value);
+        };
+
+        return <Input value={value} onChange={handleChange} placeholder="입력" />;
+      }
+
+      render(<TestComponent />);
+      const input = screen.getByPlaceholderText("입력");
+
+      await user.type(input, "test");
+      expect(input).toHaveValue("test");
+    });
+
+    test("값을 지울 수 있다", async () => {
+      const user = userEvent.setup();
+      render(<Input defaultValue="삭제될 텍스트" />);
+
+      const input = screen.getByDisplayValue("삭제될 텍스트");
+      await user.clear(input);
+
+      expect(input).toHaveValue("");
+    });
+  });
+
+  describe("에러 상태", () => {
+    test("에러 메시지가 표시된다", () => {
+      render(<Input error="필수 입력 항목입니다" aria-label="입력" />);
+
+      const input = screen.getByLabelText("입력");
+      const errorEl = screen.getByText("필수 입력 항목입니다");
+
+      expect(errorEl).toBeInTheDocument();
+      expect(input).toHaveAttribute("aria-invalid", "true");
+      expect(input).toHaveAttribute("aria-errormessage", errorEl.id);
+    });
+
+    test("에러 상태일 때 aria-invalid가 true다", () => {
+      render(<Input error="에러 발생" placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    test("에러가 없으면 aria-invalid가 없다", () => {
+      render(<Input placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      expect(input).not.toHaveAttribute("aria-invalid");
+    });
+
+    test("에러가 없으면 에러 메시지가 표시되지 않는다", () => {
+      render(<Input placeholder="입력" />);
+      const input = screen.getByPlaceholderText("입력");
+
+      expect(input).not.toHaveAttribute("aria-errormessage");
+    });
+
+    test("에러 메시지가 변경되면 화면에 반영된다", () => {
+      const { rerender } = render(<Input error="첫 번째 에러" aria-label="입력" />);
+      expect(screen.getByText("첫 번째 에러")).toBeInTheDocument();
+
+      rerender(<Input error="두 번째 에러" aria-label="입력" />);
+      expect(screen.getByText("두 번째 에러")).toBeInTheDocument();
+    });
+  });
+
+  describe("포커스 상태", () => {
+    test("포커스할 수 있다", async () => {
+      const user = userEvent.setup();
+      render(<Input placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      await user.click(input);
+
+      expect(input).toHaveFocus();
+    });
+
+    test("Tab 키로 포커스 이동이 가능하다", async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Input placeholder="첫 번째" />
+          <Input placeholder="두 번째" />
+        </>
+      );
+
+      await user.tab();
+      expect(screen.getByPlaceholderText("첫 번째")).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByPlaceholderText("두 번째")).toHaveFocus();
+    });
+
+    test("프로그래밍 방식으로 포커스할 수 있다", () => {
+      render(<Input placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      input.focus();
+      expect(input).toHaveFocus();
+    });
+  });
+
+  describe("비활성화 상태", () => {
+    test("disabled 상태가 적용된다", () => {
+      render(<Input disabled placeholder="입력" />);
+
+      expect(screen.getByPlaceholderText("입력")).toBeDisabled();
+    });
+
+    test("비활성화 상태에서 입력할 수 없다", async () => {
+      const user = userEvent.setup();
+      render(<Input disabled placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      await user.type(input, "test");
+
+      expect(input).toHaveValue("");
+    });
+
+    test("비활성화 상태에서 포커스할 수 없다", async () => {
+      const user = userEvent.setup();
+      render(<Input disabled placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      await user.click(input);
+
+      expect(input).not.toHaveFocus();
+    });
+
+    test("비활성화 상태에서도 에러 메시지는 표시된다", () => {
+      render(<Input disabled error="에러 발생" aria-label="입력" />);
+
+      const input = screen.getByLabelText("입력");
+      const errorEl = screen.getByText("에러 발생");
+
+      expect(errorEl).toBeInTheDocument();
+      expect(input).toHaveAttribute("aria-errormessage", errorEl.id);
+    });
+  });
+
+  describe("접근성", () => {
+    test("role이 textbox다", () => {
+      render(<Input />);
+
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    test("aria-label을 설정할 수 있다", () => {
+      render(<Input aria-label="사용자 이름 입력" />);
+
+      expect(screen.getByLabelText("사용자 이름 입력")).toBeInTheDocument();
+    });
+
+    test("required 속성이 적용된다", () => {
+      render(<Input required aria-label="필수 입력" />);
+
+      expect(screen.getByRole("textbox")).toBeRequired();
+    });
+
+    test("readonly 속성이 적용된다", () => {
+      render(<Input readOnly defaultValue="읽기 전용" />);
+
+      const input = screen.getByDisplayValue("읽기 전용");
+      expect(input).toHaveAttribute("readonly");
+    });
+  });
+
+  describe("커스터마이징", () => {
+    test("className으로 스타일을 확장할 수 있다", () => {
+      render(<Input className="custom-class" placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      expect(input).toHaveClass("custom-class");
+    });
+
+    test("HTML input 속성을 전달할 수 있다", () => {
+      render(<Input name="username" maxLength={50} autoComplete="username" placeholder="입력" />);
+
+      const input = screen.getByPlaceholderText("입력");
+      expect(input).toHaveAttribute("name", "username");
+      expect(input).toHaveAttribute("maxlength", "50");
+      expect(input).toHaveAttribute("autocomplete", "username");
+    });
+
+    test("id를 설정할 수 있다", () => {
+      render(<Input id="custom-id" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("id", "custom-id");
+    });
+  });
+});

--- a/src/components/CheckBox/CheckBox.test.tsx
+++ b/src/components/CheckBox/CheckBox.test.tsx
@@ -5,12 +5,6 @@ import { describe, test, expect } from "vitest";
 
 import CheckBox from "./CheckBox";
 
-//
-// =============================================================
-// Custom CheckBox Component — Detailed Test
-// (Backspace 프로젝트 커스텀 체크박스에 최적화)
-// =============================================================
-//
 describe("Custom CheckBox", () => {
   //
   // ------------------------------------------------------------------

--- a/src/components/CheckBox/CheckBox.test.tsx
+++ b/src/components/CheckBox/CheckBox.test.tsx
@@ -1,236 +1,214 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useState, type ChangeEvent } from "react";
+import { useState } from "react";
 import { describe, test, expect } from "vitest";
 
-import Input from "../Input/Input";
+import CheckBox from "./CheckBox";
 
-describe("Input", () => {
+//
+// =============================================================
+// Custom CheckBox Component — Detailed Test
+// (Backspace 프로젝트 커스텀 체크박스에 최적화)
+// =============================================================
+//
+describe("Custom CheckBox", () => {
+  //
+  // ------------------------------------------------------------------
+  // 렌더링
+  // ------------------------------------------------------------------
+  //
   describe("렌더링", () => {
-    test("기본 인풋이 렌더링 된다", () => {
-      render(<Input placeholder="텍스트 입력" />);
-      expect(screen.getByPlaceholderText("텍스트 입력")).toBeInTheDocument();
+    test("체크박스 input이 렌더링된다", () => {
+      render(<CheckBox />);
+
+      const input = screen.getByRole("checkbox");
+      expect(input).toBeInTheDocument();
     });
 
-    test("placeholder 없이도 렌더링 된다", () => {
-      render(<Input />);
-      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    test("input 바로 뒤에 Box(div)가 렌더링된다", () => {
+      render(<CheckBox />);
+      const input = screen.getByRole("checkbox");
+
+      const box = input.nextElementSibling;
+      expect(box?.tagName).toBe("DIV");
+      expect(box).toBeInTheDocument();
+    });
+
+    test("label text가 있으면 span이 렌더링된다", () => {
+      render(<CheckBox label="동의합니다" />);
+      expect(screen.getByText("동의합니다")).toBeInTheDocument();
     });
   });
 
-  describe("입력 동작", () => {
-    test("텍스트를 입력할 수 있다", async () => {
-      const user = userEvent.setup();
-      render(<Input placeholder="이름" />);
-
-      const input = screen.getByPlaceholderText("이름");
-      await user.type(input, "John Doe");
-
-      expect(input).toHaveValue("John Doe");
+  //
+  // ------------------------------------------------------------------
+  // Uncontrolled (기본 상태 관리)
+  // ------------------------------------------------------------------
+  //
+  describe("Uncontrolled 동작", () => {
+    test("기본값은 체크되지 않은 상태", () => {
+      render(<CheckBox />);
+      const input = screen.getByRole("checkbox");
+      expect(input).not.toBeChecked();
     });
 
-    test("초기값이 설정된다", () => {
-      render(<Input defaultValue="기본값" />);
+    test("input 클릭 시 체크 → 다시 클릭하면 해제된다", async () => {
+      const user = userEvent.setup();
+      render(<CheckBox label="동의" />);
 
-      expect(screen.getByDisplayValue("기본값")).toBeInTheDocument();
+      const input = screen.getByRole("checkbox");
+
+      await user.click(input);
+      expect(input).toBeChecked();
+
+      await user.click(input);
+      expect(input).not.toBeChecked();
     });
 
-    test("제어 컴포넌트로 동작한다", async () => {
+    test("label wrapper 전체를 클릭해도 체크 상태가 토글된다", async () => {
+      const user = userEvent.setup();
+      render(<CheckBox label="전체동의" />);
+
+      const label = screen.getByText("전체동의").closest("label")!;
+      const input = screen.getByRole("checkbox");
+
+      await user.click(label);
+      expect(input).toBeChecked();
+    });
+  });
+
+  //
+  // ------------------------------------------------------------------
+  // SVG 체크 아이콘
+  // ------------------------------------------------------------------
+  //
+  describe("SVG 렌더링", () => {
+    test("체크 시 SVG가 box 내부에 나타난다", async () => {
+      const user = userEvent.setup();
+      render(<CheckBox label="동의" />);
+
+      const input = screen.getByRole("checkbox");
+      const box = input.nextElementSibling as HTMLElement;
+
+      await user.click(input);
+
+      const svg = box.querySelector("svg");
+      expect(svg).not.toBeNull();
+    });
+
+    test("해제하면 SVG가 사라진다", async () => {
+      const user = userEvent.setup();
+      render(<CheckBox label="동의" />);
+
+      const input = screen.getByRole("checkbox");
+      const box = input.nextElementSibling as HTMLElement;
+
+      await user.click(input); // 체크
+      await user.click(input); // 해제
+
+      expect(box.querySelector("svg")).toBeNull();
+    });
+  });
+
+  //
+  // ------------------------------------------------------------------
+  // Controlled
+  // ------------------------------------------------------------------
+  //
+  describe("Controlled 모드", () => {
+    test("외부에서 checked 상태를 제어할 수 있다", async () => {
       const user = userEvent.setup();
 
-      function TestComponent() {
-        const [value, setValue] = useState<string>("");
-
-        const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-          setValue(e.target.value);
-        };
-
-        return <Input value={value} onChange={handleChange} placeholder="입력" />;
+      function ControlledTest() {
+        const [checked, setChecked] = useState(false);
+        return <CheckBox checked={checked} onCheckedChange={setChecked} label="동의" />;
       }
 
-      render(<TestComponent />);
-      const input = screen.getByPlaceholderText("입력");
+      render(<ControlledTest />);
+      const input = screen.getByRole("checkbox");
 
-      await user.type(input, "test");
-      expect(input).toHaveValue("test");
+      expect(input).not.toBeChecked();
+
+      await user.click(input);
+      expect(input).toBeChecked();
     });
 
-    test("값을 지울 수 있다", async () => {
+    test("controlled 모드에서 외부 checked가 true면 내부 toggle이 되지 않는다", async () => {
       const user = userEvent.setup();
-      render(<Input defaultValue="삭제될 텍스트" />);
 
-      const input = screen.getByDisplayValue("삭제될 텍스트");
-      await user.clear(input);
+      render(<CheckBox checked label="동의" />);
+      const input = screen.getByRole("checkbox");
 
-      expect(input).toHaveValue("");
+      await user.click(input);
+      expect(input).toBeChecked(); // 유지됨
     });
   });
 
-  describe("에러 상태", () => {
-    test("에러 메시지가 표시된다", () => {
-      render(<Input error="필수 입력 항목입니다" aria-label="입력" />);
+  //
+  // ------------------------------------------------------------------
+  // Disabled
+  // ------------------------------------------------------------------
+  //
+  describe("Disabled 상태", () => {
+    test("disabled 시 클릭해도 체크되지 않는다", async () => {
+      const user = userEvent.setup();
+      render(<CheckBox disabled label="동의" />);
 
-      const input = screen.getByLabelText("입력");
-      const errorEl = screen.getByText("필수 입력 항목입니다");
+      const input = screen.getByRole("checkbox");
+      await user.click(input);
 
-      expect(errorEl).toBeInTheDocument();
-      expect(input).toHaveAttribute("aria-invalid", "true");
-      expect(input).toHaveAttribute("aria-errormessage", errorEl.id);
+      expect(input).not.toBeChecked();
     });
 
-    test("에러 상태일 때 aria-invalid가 true다", () => {
-      render(<Input error="에러 발생" placeholder="입력" />);
+    test("wrapper(label)에 disabled 스타일(pointer-events-none)이 적용된다", () => {
+      render(<CheckBox disabled label="동의" />);
 
-      const input = screen.getByPlaceholderText("입력");
-      expect(input).toHaveAttribute("aria-invalid", "true");
-    });
-
-    test("에러가 없으면 aria-invalid가 없다", () => {
-      render(<Input placeholder="입력" />);
-
-      const input = screen.getByPlaceholderText("입력");
-      expect(input).not.toHaveAttribute("aria-invalid");
-    });
-
-    test("에러가 없으면 에러 메시지가 표시되지 않는다", () => {
-      render(<Input placeholder="입력" />);
-      const input = screen.getByPlaceholderText("입력");
-
-      expect(input).not.toHaveAttribute("aria-errormessage");
-    });
-
-    test("에러 메시지가 변경되면 화면에 반영된다", () => {
-      const { rerender } = render(<Input error="첫 번째 에러" aria-label="입력" />);
-      expect(screen.getByText("첫 번째 에러")).toBeInTheDocument();
-
-      rerender(<Input error="두 번째 에러" aria-label="입력" />);
-      expect(screen.getByText("두 번째 에러")).toBeInTheDocument();
+      const wrapper = screen.getByText("동의").closest("label")!;
+      expect(wrapper.className).toContain("pointer-events-none");
     });
   });
 
+  //
+  // ------------------------------------------------------------------
+  // Focus 스타일 (@utility focus-dotted)
+  // ------------------------------------------------------------------
   describe("포커스 상태", () => {
-    test("포커스할 수 있다", async () => {
+    test("input 클릭 시 포커스가 정상적으로 이동한다", async () => {
       const user = userEvent.setup();
-      render(<Input placeholder="입력" />);
+      render(<CheckBox label="동의" />);
 
-      const input = screen.getByPlaceholderText("입력");
+      const input = screen.getByRole("checkbox");
+      const text = screen.getByText("동의");
+
+      // 1) span 자체는 focus를 얻지 않음
+      expect(text).not.toHaveFocus();
+
+      // 2) input 클릭 → input은 focus를 얻어야 한다.
       await user.click(input);
-
       expect(input).toHaveFocus();
-    });
 
-    test("Tab 키로 포커스 이동이 가능하다", async () => {
-      const user = userEvent.setup();
-      render(
-        <>
-          <Input placeholder="첫 번째" />
-          <Input placeholder="두 번째" />
-        </>
-      );
+      // 3) group-focus-within 구조가 올바르게 렌더링되어야 함 (DOM 검증)
+      const wrapper = text.closest("label")!;
+      expect(wrapper.className).toContain("group");
 
-      await user.tab();
-      expect(screen.getByPlaceholderText("첫 번째")).toHaveFocus();
-
-      await user.tab();
-      expect(screen.getByPlaceholderText("두 번째")).toHaveFocus();
-    });
-
-    test("프로그래밍 방식으로 포커스할 수 있다", () => {
-      render(<Input placeholder="입력" />);
-
-      const input = screen.getByPlaceholderText("입력");
-      input.focus();
-      expect(input).toHaveFocus();
+      // Tailwind는 class가 변경되지 않기 때문에 style 검사 불가.
+      // 대신 구조적으로 group-focus-within이 적용 가능한지 확인한다.
     });
   });
 
-  describe("비활성화 상태", () => {
-    test("disabled 상태가 적용된다", () => {
-      render(<Input disabled placeholder="입력" />);
+  //
+  // ------------------------------------------------------------------
+  // className 확장
+  // ------------------------------------------------------------------
+  //
+  describe("className 확장", () => {
+    test("box(div)에 className 확장 가능", () => {
+      render(<CheckBox className="custom-box" />);
 
-      expect(screen.getByPlaceholderText("입력")).toBeDisabled();
-    });
+      const input = screen.getByRole("checkbox");
+      const box = input.nextElementSibling as HTMLElement;
 
-    test("비활성화 상태에서 입력할 수 없다", async () => {
-      const user = userEvent.setup();
-      render(<Input disabled placeholder="입력" />);
-
-      const input = screen.getByPlaceholderText("입력");
-      await user.type(input, "test");
-
-      expect(input).toHaveValue("");
-    });
-
-    test("비활성화 상태에서 포커스할 수 없다", async () => {
-      const user = userEvent.setup();
-      render(<Input disabled placeholder="입력" />);
-
-      const input = screen.getByPlaceholderText("입력");
-      await user.click(input);
-
-      expect(input).not.toHaveFocus();
-    });
-
-    test("비활성화 상태에서도 에러 메시지는 표시된다", () => {
-      render(<Input disabled error="에러 발생" aria-label="입력" />);
-
-      const input = screen.getByLabelText("입력");
-      const errorEl = screen.getByText("에러 발생");
-
-      expect(errorEl).toBeInTheDocument();
-      expect(input).toHaveAttribute("aria-errormessage", errorEl.id);
-    });
-  });
-
-  describe("접근성", () => {
-    test("role이 textbox다", () => {
-      render(<Input />);
-
-      expect(screen.getByRole("textbox")).toBeInTheDocument();
-    });
-
-    test("aria-label을 설정할 수 있다", () => {
-      render(<Input aria-label="사용자 이름 입력" />);
-
-      expect(screen.getByLabelText("사용자 이름 입력")).toBeInTheDocument();
-    });
-
-    test("required 속성이 적용된다", () => {
-      render(<Input required aria-label="필수 입력" />);
-
-      expect(screen.getByRole("textbox")).toBeRequired();
-    });
-
-    test("readonly 속성이 적용된다", () => {
-      render(<Input readOnly defaultValue="읽기 전용" />);
-
-      const input = screen.getByDisplayValue("읽기 전용");
-      expect(input).toHaveAttribute("readonly");
-    });
-  });
-
-  describe("커스터마이징", () => {
-    test("className으로 스타일을 확장할 수 있다", () => {
-      render(<Input className="custom-class" placeholder="입력" />);
-
-      const input = screen.getByPlaceholderText("입력");
-      expect(input).toHaveClass("custom-class");
-    });
-
-    test("HTML input 속성을 전달할 수 있다", () => {
-      render(<Input name="username" maxLength={50} autoComplete="username" placeholder="입력" />);
-
-      const input = screen.getByPlaceholderText("입력");
-      expect(input).toHaveAttribute("name", "username");
-      expect(input).toHaveAttribute("maxlength", "50");
-      expect(input).toHaveAttribute("autocomplete", "username");
-    });
-
-    test("id를 설정할 수 있다", () => {
-      render(<Input id="custom-id" />);
-
-      const input = screen.getByRole("textbox");
-      expect(input).toHaveAttribute("id", "custom-id");
+      expect(box).toHaveClass("custom-box");
     });
   });
 });

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+
+import CheckBoxWrapper from "./CheckBoxWrapper";
+
+interface CheckBoxProps {
+  label?: string;
+  disabled?: boolean;
+  checked?: boolean; // controlled
+  onCheckedChange?: (checked: boolean) => void;
+  className?: string;
+}
+
+/**
+ * 공통 체크박스 컴포넌트
+ *
+ * 제어(Controlled) / 비제어(Uncontrolled) 방식을 모두 지원하며,
+ * 라벨·비활성화 상태·상위 전달 이벤트 등을 조합하여 사용할 수 있습니다.
+ *
+ * @component
+ * @param {string} [label] - 체크박스 우측에 표시되는 라벨 텍스트
+ * @param {boolean} [disabled=false] - 체크박스 비활성화 여부
+ * @param {boolean} [checked] - 제어(Controlled) 모드에서 사용하는 체크 상태
+ * @param {(checked: boolean) => void} [onCheckedChange] - 체크 상태 변경 콜백
+ * @param {string} [className] - 추가 Tailwind 클래스
+ * @returns {JSX.Element} 체크박스 엘리먼트
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled (내부 상태로 관리됨)
+ * <CheckBox label="동의합니다" />
+ *
+ * // Controlled (상위에서 상태를 제어)
+ * const [checked, setChecked] = useState(false);
+ * <CheckBox
+ *   label="약관 동의"
+ *   checked={checked}
+ *   onCheckedChange={setChecked}
+ * />
+ * ```
+ */
+
+export default function CheckBox({
+  label,
+  disabled = false,
+  checked,
+  onCheckedChange,
+  className,
+}: CheckBoxProps) {
+  const [internalChecked, setInternalChecked] = useState(false);
+
+  const isControlled = checked !== undefined;
+
+  const currentChecked = isControlled ? checked : internalChecked;
+
+  const handleToggle = (isChecked: boolean) => {
+    if (!isControlled) {
+      setInternalChecked(isChecked);
+    }
+
+    onCheckedChange?.(isChecked);
+  };
+
+  return (
+    <CheckBoxWrapper
+      label={label}
+      disabled={disabled}
+      checked={currentChecked}
+      onCheckedChange={handleToggle}
+      className={className}
+    />
+  );
+}

--- a/src/components/CheckBox/CheckBoxWrapper.tsx
+++ b/src/components/CheckBox/CheckBoxWrapper.tsx
@@ -34,7 +34,8 @@ export default function CheckBoxWrapper({
         checkBoxWrapper({
           hasLabel: Boolean(label),
           isDisabled: disabled,
-        })
+        }),
+        className
       )}
       {...rest}
     >
@@ -47,7 +48,7 @@ export default function CheckBoxWrapper({
         onChange={(e) => onCheckedChange?.(e.target.checked)}
       />
 
-      <Box isChecked={checked} isDisabled={disabled} className={className} />
+      <Box isChecked={checked} isDisabled={disabled} />
 
       {label && <span className="group-focus-within:focus-dotted">{label}</span>}
     </label>

--- a/src/components/CheckBox/CheckBoxWrapper.tsx
+++ b/src/components/CheckBox/CheckBoxWrapper.tsx
@@ -31,7 +31,6 @@ export default function CheckBoxWrapper({
     <label
       htmlFor={id}
       className={twMerge(
-        "group",
         checkBoxWrapper({
           hasLabel: Boolean(label),
           isDisabled: disabled,

--- a/src/components/CheckBox/CheckBoxWrapper.tsx
+++ b/src/components/CheckBox/CheckBoxWrapper.tsx
@@ -34,15 +34,10 @@ export default function CheckBoxWrapper({
         checkBoxWrapper({
           hasLabel: Boolean(label),
           isDisabled: disabled,
-        }),
-        className
+        })
       )}
       {...rest}
     >
-      <Box isChecked={checked} isDisabled={disabled} />
-
-      {label && <span className="group-focus-within:focus-dotted">{label}</span>}
-
       <input
         id={id}
         type="checkbox"
@@ -51,6 +46,10 @@ export default function CheckBoxWrapper({
         disabled={disabled}
         onChange={(e) => onCheckedChange?.(e.target.checked)}
       />
+
+      <Box isChecked={checked} isDisabled={disabled} className={className} />
+
+      {label && <span className="group-focus-within:focus-dotted">{label}</span>}
     </label>
   );
 }

--- a/src/components/CheckBox/CheckBoxWrapper.tsx
+++ b/src/components/CheckBox/CheckBoxWrapper.tsx
@@ -1,0 +1,57 @@
+import { useId } from "react";
+import { twMerge } from "tailwind-merge";
+
+import Box from "./Box";
+import { checkBoxWrapper, type WrapperVariantProps } from "./variants/wrapperVariants";
+
+interface CheckBoxWrapperProps
+  extends React.ComponentPropsWithoutRef<"label">,
+    WrapperVariantProps {
+  label?: string;
+  checked?: boolean;
+  disabled?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export default function CheckBoxWrapper({
+  label,
+  checked = false,
+  disabled = false,
+  onCheckedChange,
+  className,
+  ...rest
+}: CheckBoxWrapperProps) {
+  const customId = rest.id;
+  const generatedId = useId();
+
+  // props로 id를 전달받으면 그것을 쓰고, 아니면 useId로 생성한 id를 사용
+  const id = customId ?? generatedId;
+
+  return (
+    <label
+      htmlFor={id}
+      className={twMerge(
+        "group",
+        checkBoxWrapper({
+          hasLabel: Boolean(label),
+          isDisabled: disabled,
+        }),
+        className
+      )}
+      {...rest}
+    >
+      <Box isChecked={checked} isDisabled={disabled} />
+
+      {label && <span className="group-focus-within:focus-dotted">{label}</span>}
+
+      <input
+        id={id}
+        type="checkbox"
+        className="sr-only"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onCheckedChange?.(e.target.checked)}
+      />
+    </label>
+  );
+}

--- a/src/components/CheckBox/variants/boxVariants.ts
+++ b/src/components/CheckBox/variants/boxVariants.ts
@@ -1,0 +1,18 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+export const checkBox = cva(
+  [
+    "bevel-pressed",
+    "relative flex items-center justify-center transition-all",
+    "h-4.5 w-4.5 p-[3.6px] select-none",
+  ],
+  {
+    variants: {
+      isDisabled: {
+        true: "disabled-base",
+      },
+    },
+  }
+);
+
+export type CheckBoxVariantProps = VariantProps<typeof checkBox>;

--- a/src/components/CheckBox/variants/wrapperVariants.ts
+++ b/src/components/CheckBox/variants/wrapperVariants.ts
@@ -1,0 +1,20 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+export const checkBoxWrapper = cva(["flex items-center", "select-none"], {
+  variants: {
+    hasLabel: {
+      true: "gap-3",
+      false: "",
+    },
+    isDisabled: {
+      true: "disabled-base pointer-events-none",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    hasLabel: true,
+    isDisabled: false,
+  },
+});
+
+export type WrapperVariantProps = VariantProps<typeof checkBoxWrapper>;

--- a/src/components/CheckBox/variants/wrapperVariants.ts
+++ b/src/components/CheckBox/variants/wrapperVariants.ts
@@ -1,20 +1,23 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
-export const checkBoxWrapper = cva(["flex items-center", "select-none"], {
-  variants: {
-    hasLabel: {
-      true: "gap-3",
-      false: "",
+export const checkBoxWrapper = cva(
+  ["inline-flex items-center", "group", "align-middle", "select-none"],
+  {
+    variants: {
+      hasLabel: {
+        true: "gap-3",
+        false: "",
+      },
+      isDisabled: {
+        true: "disabled-base pointer-events-none",
+        false: "",
+      },
     },
-    isDisabled: {
-      true: "disabled-base pointer-events-none",
-      false: "",
+    defaultVariants: {
+      hasLabel: true,
+      isDisabled: false,
     },
-  },
-  defaultVariants: {
-    hasLabel: true,
-    isDisabled: false,
-  },
-});
+  }
+);
 
 export type WrapperVariantProps = VariantProps<typeof checkBoxWrapper>;


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- cva를 활용해 커스텀 체크박스를 구현했습니다.

## ✅ 관련 이슈

- Close #31 

## 🛠️ 상세 작업 내용

- [x] 체크박스 UI 기본 구조 설계
  - CheckBox → CheckBoxWrapper → Box 구조로 컴포넌트 분리
  - Wrapper는 라벨/정렬/포커스 처리 담당
  - Box는 실제 체크박스 UI(정사각형 · bevel · padding 등) 담당
- [x] Controlled / Uncontrolled 모드 모두 지원
  - checked + onCheckedChange 전달 시 제어 컴포넌트(Controlled) 로 동작
  - 전달하지 않을 경우 내부 useState 로 비제어(Uncontrolled) 방식으로 사용 가능
  - 이벤트 발생 시 onCheckedChange(checked) 콜백 실행
- [x] 포커스 시 dotted-outline 효과 적용
  - label 그룹 전체가 focus될 때 focus-dotted 유틸리티가 적용 

## ⚠️ 주의 사항 (옵션)

<!-- 다른 작업물에 영향을 줄 수 있는 변화가 있다면 적어주세요 -->
1. checked를 전달하는 순간 Controlled 모드로 전환됨
	•	이 경우 체크박스 자체는 내부 상태를 변경하지 않는다.
	•	즉, 클릭해도 상태가 바뀌지 않는다.
	•	반드시 상위에서 상태를 관리하고 onCheckedChange로 업데이트해야 한다.

2. checked를 전달하지 않으면 Uncontrolled 모드
	•	내부 useState로 체크 상태가 자동으로 관리된다.
	•	별도의 상태 관리가 필요 없고 클릭 시 자동 토글된다.

3. disabled는 UI 및 인터랙션을 함께 비활성화
	•	단순히 스타일만 흐려지는 것이 아니라
클릭, 포커스, 토글 모두 차단된다.
	•	CheckboxWrapper 내부에서 pointer-events-none을 적용함.

## 📸 스크린샷 (옵션)

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->
<img width="433" height="464" alt="스크린샷 2025-11-10 오후 10 11 16" src="https://github.com/user-attachments/assets/e7cf384c-1946-427a-974b-212f0a3d7340" />

## 👥 리뷰 확인 사항 (옵션)

<!-- 코드 리뷰 시에 특별히 확인해야 하는 사항이 있으면 적어주세요 -->
<!-- 예시: 제가 지정한 타입 정의가 적절한지 확인 부탁드립니다 -->
