### PR TITLE
[#43] feat(input): add error state styling and icon

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,7 +74,11 @@ export default [
   ...pluginQuery.configs["flat/recommended"],
   ...prettierConfig,
   {
-    name: "custom/import-resolver",
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
     settings: {
       "import-x/resolver": {
         typescript: {
@@ -87,20 +91,37 @@ export default [
         },
       },
     },
-  },
-  {
-    name: "custom/overrides",
     rules: {
       "react/react-in-jsx-scope": "off",
-      "react/require-default-props": "off",
       "react/jsx-uses-react": "off",
+      "react/require-default-props": "off",
+      "react/jsx-props-no-spreading": "off",
+      "react/function-component-definition": "off",
+      "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
+
+      "react/prop-types": "off",
+      "no-use-before-define": "off",
+      "@typescript-eslint/no-use-before-define": "off",
+
+      "no-plusplus": "off",
+      "no-param-reassign": ["error", { props: false }],
+      "consistent-return": "off",
+
+      "jsx-a11y/label-has-associated-control": [
+        "error",
+        {
+          assert: "either",
+          controlComponents: ["Input"],
+          depth: 3,
+        },
+      ],
+
       "import-x/extensions": "off",
       "import-x/prefer-default-export": "off",
+      "import-x/no-extraneous-dependencies": "off",
       "import-x/first": "error",
       "import-x/no-duplicates": "error",
-      "import-x/no-extraneous-dependencies": "off",
       "import-x/newline-after-import": ["error", { count: 1 }],
-
       "import-x/order": [
         "error",
         {

--- a/src/components/CheckBox/CheckBox.test.tsx
+++ b/src/components/CheckBox/CheckBox.test.tsx
@@ -196,13 +196,12 @@ describe("Custom CheckBox", () => {
   // ------------------------------------------------------------------
   //
   describe("className 확장", () => {
-    test("box(div)에 className 확장 가능", () => {
-      render(<CheckBox className="custom-box" />);
+    test("className은 wrapper(label)에 적용된다", () => {
+      render(<CheckBox label="Agree" className="custom-class" />);
 
       const input = screen.getByRole("checkbox");
-      const box = input.nextElementSibling as HTMLElement;
-
-      expect(box).toHaveClass("custom-box");
+      const wrapper = input.closest("label")!;
+      expect(wrapper).toHaveClass("custom-class");
     });
   });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import { useId, type ComponentPropsWithoutRef } from "react";
 import { twMerge } from "tailwind-merge";
 
 interface InputProps extends ComponentPropsWithoutRef<"input"> {
+  id?: string | undefined;
   error?: string | undefined;
 }
 
@@ -10,6 +11,10 @@ interface InputProps extends ComponentPropsWithoutRef<"input"> {
  * 기본 Input 컴포넌트
  *
  * @component
+ *
+ *  @param {string} [id]
+ *   - input의 id 속성입니다.
+ *   - 외부 `<label htmlFor>`과 연결할 때 사용합니다.
  *
  * @param {string} [error]
  *   - 에러 메시지 문자열입니다. 값이 있으면 input에 에러 스타일이 적용되고 하단에 에러 메시지가 표시됩니다.
@@ -32,13 +37,14 @@ interface InputProps extends ComponentPropsWithoutRef<"input"> {
  * />
  * ```
  */
-export default function Input({ error, className, ...props }: InputProps) {
+export default function Input({ id, error, className, ...props }: InputProps) {
   const errorId = useId();
 
   return (
     <div className="flex flex-col justify-center gap-1">
       <div className="relative">
         <input
+          id={id}
           className={twMerge(
             "bevel-pressed w-full px-2 py-1.5",
             "border-2 border-transparent outline-none",
@@ -52,6 +58,7 @@ export default function Input({ error, className, ...props }: InputProps) {
         {error && (
           <CircleAlert
             aria-hidden="true"
+            size={16}
             className="text-error pointer-events-none absolute top-1/2 right-2 -translate-y-1/2"
           />
         )}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { CircleAlert } from "lucide-react";
 import { useId, type ComponentPropsWithoutRef } from "react";
 import { twMerge } from "tailwind-merge";
 
@@ -36,17 +37,25 @@ export default function Input({ error, className, ...props }: InputProps) {
 
   return (
     <div className="flex flex-col justify-center gap-1">
-      <input
-        className={twMerge(
-          "bevel-pressed px-2 py-1.5",
-          "border-2 border-transparent outline-none",
-          "focus:border-accent/80 disabled:disabled-base",
-          error && "bevel-error",
-          className
+      <div className="relative">
+        <input
+          className={twMerge(
+            "bevel-pressed w-full px-2 py-1.5",
+            "border-2 border-transparent outline-none",
+            "focus:border-primary/80 disabled:disabled-base",
+            error && "error-tint pr-8",
+            className
+          )}
+          {...props}
+          {...(error && { "aria-invalid": true, "aria-errormessage": errorId })}
+        />
+        {error && (
+          <CircleAlert
+            aria-hidden="true"
+            className="text-error pointer-events-none absolute top-1/2 right-2 -translate-y-1/2"
+          />
         )}
-        {...props}
-        {...(error && { "aria-invalid": true, "aria-errormessage": errorId })}
-      />
+      </div>
       {error && (
         <span id={errorId} className="text-error px-1 text-xs">
           {error}

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -30,3 +30,11 @@
 @utility focus-dotted {
   outline: 1px dotted var(--color-text-default);
 }
+
+@utility error-tint {
+  background-color: color-mix(in srgb, var(--color-error) 10%, var(--color-surface));
+
+  &:focus {
+    background-color: color-mix(in srgb, var(--color-error) 20%, var(--color-surface));
+  }
+}


### PR DESCRIPTION
## 📖 개요

- Input 컴포넌트 에러 상태 베벨에서 틴트 및 아이콘 표시로 변경

## ✅ 관련 이슈

- Close #43 

## 🛠️ 상세 작업 내용

- [x] Input 컴포넌트 에러 상태 UI 개선
- [x] `utilities.css`에 `@utility input-error` 추가

## 📸 스크린샷

**before:**
<img width="418" height="225" alt="스크린샷 2025-11-10 05 32 28" src="https://github.com/user-attachments/assets/52c79774-ad46-46bf-87cd-f34fc8198073" />

**after:**
<img width="743" height="150" alt="스크린샷 2025-11-11 15 30 28" src="https://github.com/user-attachments/assets/e623458b-77a4-48a7-9e4c-79265a2db353" />

**focus:**
<img width="737" height="143" alt="스크린샷 2025-11-11 15 50 00" src="https://github.com/user-attachments/assets/fafb7f9e-34c0-4ad7-ba30-786d5353fd01" />
8221" />

## 👥 리뷰 확인 사항

포커스까지 에러 색상으로 하면 너무 강조되는 느낌이라 일단 이렇게 바꿔봤습니다 🙏