### PR TITLE
[#35] feat(ui): RoundedTab 컴포넌트 구현

### DIFF
--- a/src/components/Tab/RoundedTab.tsx
+++ b/src/components/Tab/RoundedTab.tsx
@@ -41,16 +41,17 @@ export default function RoundedTab({ children, className, ...rest }: TabProps) {
       type="button"
       className={twMerge(
         "relative inline-flex cursor-pointer items-center justify-center",
+        // "pt-px pr-px pb-1.5 pl-px",
         "px-3 py-1.5 text-xs",
         "whitespace-nowrap",
-        "mr-0.5",
         "z-0",
+        // "overflow-hidden",
         className
       )}
       {...rest}
     >
       {/* 레이어 컨테이너 - 모든 레이어를 묶는 기준 컨테이너 */}
-      <div className="absolute inset-0">
+      <div className="absolute top-px right-px bottom-0 left-px">
         {/* 상단 하이라이트 - 내부 */}
         <div className="absolute top-0 right-0.25 left-0.25 h-px bg-[var(--color-bevel-light-inner)]" />
         {/* 상단 하이라이트 - 외부 */}

--- a/src/components/Tab/RoundedTab.tsx
+++ b/src/components/Tab/RoundedTab.tsx
@@ -1,0 +1,72 @@
+import { twMerge } from "tailwind-merge";
+
+interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
+  children: React.ReactNode;
+}
+
+/**
+ * RoundedTab 컴포넌트
+ *
+ * Rounded 탭 컴포넌트입니다.
+ * 하단이 잘려있고 상단 모서리가 둥근 탭을 div 레이어를 쌓아서 구현했습니다.
+ *
+ * @component
+ * @param {React.ReactNode} children - 탭에 표시할 내용
+ * @param {string} [className] - 추가 Tailwind CSS 클래스
+ * @param {React.MouseEventHandler<HTMLButtonElement>} [onClick] - 클릭 이벤트 핸들러
+ * @param {React.ButtonHTMLAttributes<HTMLButtonElement>} [rest] - button 요소의 나머지 속성들
+ * @returns {JSX.Element} RoundedTab 버튼 엘리먼트
+ *
+ * @example
+ * ```tsx
+ * // 기본 사용
+ * <RoundedTab>Tab 1</RoundedTab>
+ *
+ * // 클릭 이벤트
+ * <RoundedTab onClick={() => console.log("Tab clicked")}>
+ *   Clickable Tab
+ * </RoundedTab>
+ *
+ * // 여러 탭 그룹
+ * <div className="flex items-end gap-0">
+ *   <RoundedTab>Tab 1</RoundedTab>
+ *   <RoundedTab>Tab 2</RoundedTab>
+ *   <RoundedTab>Tab 3</RoundedTab>
+ * </div>
+ * ```
+ */
+export default function RoundedTab({ children, className, ...rest }: TabProps) {
+  return (
+    <button
+      type="button"
+      className={twMerge(
+        "relative inline-flex cursor-pointer items-center justify-center",
+        "px-3 py-1.5 text-xs",
+        "whitespace-nowrap",
+        "mr-0.5",
+        "z-0",
+        className
+      )}
+      {...rest}
+    >
+      {/* 레이어 컨테이너 - 모든 레이어를 묶는 기준 컨테이너 */}
+      <div className="absolute inset-0">
+        {/* 상단 하이라이트 - 내부 */}
+        <div className="absolute top-0 right-0.25 left-0.25 h-px bg-[var(--color-bevel-light-inner)]" />
+        {/* 상단 하이라이트 - 외부 */}
+        <div className="absolute top-[-1px] right-0.5 left-0.5 h-px bg-[var(--color-bevel-light-outer)]" />
+        {/* 좌측 하이라이트 - 내부 */}
+        <div className="absolute top-0.5 bottom-0 left-0 w-px bg-[var(--color-bevel-light-outer)]" />
+        {/* 좌측 하이라이트 - 외부 */}
+        <div className="absolute top-0.5 bottom-0 left-[-1px] w-px bg-[var(--color-bevel-light-outer)]" />
+        {/* 우측 그림자 - 내부 */}
+        <div className="absolute top-0.5 right-0 bottom-0 w-px bg-[var(--color-bevel-shadow-inner)]" />
+        {/* 우측 그림자 - 외부 */}
+        <div className="absolute top-0.5 right-[-1px] bottom-0 w-px bg-[var(--color-bevel-shadow-outer)]" />
+        {/* 배경 - 메인 바디 */}
+        <div className="absolute top-px right-px bottom-0 left-px z-0 bg-[var(--color-surface)]" />
+      </div>
+      <span className="relative z-10">{children}</span>
+    </button>
+  );
+}

--- a/src/components/Tab/RoundedTab.tsx
+++ b/src/components/Tab/RoundedTab.tsx
@@ -2,16 +2,19 @@ import { twMerge } from "tailwind-merge";
 
 interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
   children: React.ReactNode;
+  selected?: boolean;
 }
 
 /**
  * RoundedTab 컴포넌트
  *
  * Rounded 탭 컴포넌트입니다.
- * 하단이 잘려있고 상단 모서리가 둥근 탭을 div 레이어를 쌓아서 구현했습니다.
+ * 하단이 잘려있고 상단 모서리가 둥근 Windows 98 스타일 탭을 div 레이어를 쌓아서 구현했습니다.
+ * bevel 효과를 위해 여러 개의 div 레이어를 절대 위치로 배치하여 3D 효과를 구현했습니다.
  *
  * @component
- * @param {React.ReactNode} children - 탭에 표시할 내용
+ * @param {React.ReactNode} children - 탭에 표시할 내용 (텍스트, 아이콘 등)
+ * @param {boolean} [selected=false] - 탭의 선택 상태. true일 때 하단에 surface 색 줄이 추가되고, 좌우 하이라이트/그림자가 3px 아래로 확장되어 윈도우와 연결됩니다.
  * @param {string} [className] - 추가 Tailwind CSS 클래스
  * @param {React.MouseEventHandler<HTMLButtonElement>} [onClick] - 클릭 이벤트 핸들러
  * @param {React.ButtonHTMLAttributes<HTMLButtonElement>} [rest] - button 요소의 나머지 속성들
@@ -22,20 +25,34 @@ interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
  * // 기본 사용
  * <RoundedTab>Tab 1</RoundedTab>
  *
+ * // selected 탭
+ * <RoundedTab selected>Selected Tab</RoundedTab>
+ *
  * // 클릭 이벤트
  * <RoundedTab onClick={() => console.log("Tab clicked")}>
  *   Clickable Tab
  * </RoundedTab>
  *
- * // 여러 탭 그룹
+ * // 여러 탭 그룹 (selected 탭과 함께)
  * <div className="flex items-end gap-0">
- *   <RoundedTab>Tab 1</RoundedTab>
+ *   <RoundedTab selected>Tab 1</RoundedTab>
  *   <RoundedTab>Tab 2</RoundedTab>
  *   <RoundedTab>Tab 3</RoundedTab>
  * </div>
+ *
+ * // 탭과 컨텐츠 영역 함께 사용
+ * <div>
+ *   <div className="flex items-end gap-0">
+ *     <RoundedTab selected>Tab 1</RoundedTab>
+ *     <RoundedTab>Tab 2</RoundedTab>
+ *   </div>
+ *   <div className="bevel-default bg-[var(--color-surface)] p-4">
+ *     컨텐츠 영역입니다.
+ *   </div>
+ * </div>
  * ```
  */
-export default function RoundedTab({ children, className, ...rest }: TabProps) {
+export default function RoundedTab({ children, className, selected, ...rest }: TabProps) {
   return (
     <button
       type="button"
@@ -57,17 +74,41 @@ export default function RoundedTab({ children, className, ...rest }: TabProps) {
         {/* 상단 하이라이트 - 외부 */}
         <div className="absolute top-[-1px] right-0.5 left-0.5 h-px bg-[var(--color-bevel-light-outer)]" />
         {/* 좌측 하이라이트 - 내부 */}
-        <div className="absolute top-0.5 bottom-0 left-0 w-px bg-[var(--color-bevel-light-outer)]" />
+        <div
+          className={twMerge(
+            "absolute top-0.5 left-0 w-px bg-[var(--color-bevel-light-outer)]",
+            selected ? "bottom-[-3px]" : "bottom-0"
+          )}
+        />
         {/* 좌측 하이라이트 - 외부 */}
-        <div className="absolute top-0.5 bottom-0 left-[-1px] w-px bg-[var(--color-bevel-light-outer)]" />
+        <div
+          className={twMerge(
+            "absolute top-0.5 -left-px w-px bg-[var(--color-bevel-light-outer)]",
+            selected ? "bottom-[-3px]" : "bottom-0"
+          )}
+        />
         {/* 우측 그림자 - 내부 */}
-        <div className="absolute top-0.5 right-0 bottom-0 w-px bg-[var(--color-bevel-shadow-inner)]" />
+        <div
+          className={twMerge(
+            "absolute top-0.5 right-0 w-px bg-[var(--color-bevel-shadow-inner)]",
+            selected ? "bottom-[-3px]" : "bottom-0"
+          )}
+        />
         {/* 우측 그림자 - 외부 */}
-        <div className="absolute top-0.5 right-[-1px] bottom-0 w-px bg-[var(--color-bevel-shadow-outer)]" />
+        <div
+          className={twMerge(
+            "absolute top-0.5 -right-px w-px bg-[var(--color-bevel-shadow-outer)]",
+            selected ? "bottom-[-3px]" : "bottom-0"
+          )}
+        />
         {/* 배경 - 메인 바디 */}
         <div className="absolute top-px right-px bottom-0 left-px z-0 bg-[var(--color-surface)]" />
       </div>
-      <span className="relative z-10">{children}</span>
+      {/* selected일 때 하단 surface 색 줄 - 윈도우와 배경을 잇기 위한 줄 */}
+      {selected && (
+        <div className="absolute right-[2px] bottom-[-3px] left-[2px] h-[3px] bg-[var(--color-surface)]" />
+      )}
+      <span className="relative">{children}</span>
     </button>
   );
 }

--- a/src/components/Tab/RoundedTab.tsx
+++ b/src/components/Tab/RoundedTab.tsx
@@ -12,6 +12,15 @@ interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
  * 하단이 잘려있고 상단 모서리가 둥근 Windows 98 스타일 탭을 div 레이어를 쌓아서 구현했습니다.
  * bevel 효과를 위해 여러 개의 div 레이어를 절대 위치로 배치하여 3D 효과를 구현했습니다.
  *
+ * 반응형 동작
+ * - 화면이 줄어들면 탭 너비가 자동으로 축소됩니다 (`min-w-0 shrink`)
+ * - 긴 텍스트는 ellipsis(`...`)로 표시됩니다 (`text-ellipsis`)
+ * - 텍스트는 줄바꿈되지 않습니다 (`whitespace-nowrap`)
+ *
+ * selected 상태:
+ * - 하단에 surface 색의 3px 높이 줄이 추가되어 윈도우와 연결됩니다
+ * - 좌우 하이라이트와 그림자가 3px 아래로 확장됩니다
+ *
  * @component
  * @param {React.ReactNode} children - 탭에 표시할 내용 (텍스트, 아이콘 등)
  * @param {boolean} [selected=false] - 탭의 선택 상태. true일 때 하단에 surface 색 줄이 추가되고, 좌우 하이라이트/그림자가 3px 아래로 확장되어 윈도우와 연결됩니다.
@@ -46,9 +55,16 @@ interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
  *     <RoundedTab selected>Tab 1</RoundedTab>
  *     <RoundedTab>Tab 2</RoundedTab>
  *   </div>
- *   <div className="bevel-default bg-[var(--color-surface)] p-4">
+ *   <div className="bevel-default bg-surface p-4">
  *     컨텐츠 영역입니다.
  *   </div>
+ * </div>
+ *
+ * // 긴 텍스트 탭 (자동으로 ellipsis 처리됨)
+ * <div className="flex items-end gap-0">
+ *   <RoundedTab>Short</RoundedTab>
+ *   <RoundedTab>Medium Tab</RoundedTab>
+ *   <RoundedTab>Super duper longer tab name that will be truncated</RoundedTab>
  * </div>
  * ```
  */
@@ -56,13 +72,11 @@ export default function RoundedTab({ children, className, selected, ...rest }: T
   return (
     <button
       type="button"
+      role="tab"
+      aria-selected={selected}
       className={twMerge(
         "relative inline-flex cursor-pointer items-center justify-center",
-        // "pt-px pr-px pb-1.5 pl-px",
-        "px-3 py-1.5 text-xs",
-        "whitespace-nowrap",
-        "z-0",
-        // "overflow-hidden",
+        "min-w-0 shrink px-0 py-1 text-xs whitespace-nowrap",
         className
       )}
       {...rest}
@@ -70,45 +84,47 @@ export default function RoundedTab({ children, className, selected, ...rest }: T
       {/* 레이어 컨테이너 - 모든 레이어를 묶는 기준 컨테이너 */}
       <div className="absolute top-px right-px bottom-0 left-px">
         {/* 상단 하이라이트 - 내부 */}
-        <div className="absolute top-0 right-0.25 left-0.25 h-px bg-[var(--color-bevel-light-inner)]" />
+        <div className="bg-bevel-light-inner absolute top-0 right-0.25 left-0.25 h-px" />
         {/* 상단 하이라이트 - 외부 */}
-        <div className="absolute top-[-1px] right-0.5 left-0.5 h-px bg-[var(--color-bevel-light-outer)]" />
+        <div className="bg-bevel-light-outer absolute -top-px right-0.5 left-0.5 h-px" />
         {/* 좌측 하이라이트 - 내부 */}
         <div
           className={twMerge(
-            "absolute top-0.5 left-0 w-px bg-[var(--color-bevel-light-outer)]",
-            selected ? "bottom-[-3px]" : "bottom-0"
+            "bg-bevel-light-outer absolute top-0.5 left-0 w-px",
+            selected ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 좌측 하이라이트 - 외부 */}
         <div
           className={twMerge(
-            "absolute top-0.5 -left-px w-px bg-[var(--color-bevel-light-outer)]",
-            selected ? "bottom-[-3px]" : "bottom-0"
+            "bg-bevel-light-outer absolute top-0.5 -left-px w-px",
+            selected ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 우측 그림자 - 내부 */}
         <div
           className={twMerge(
-            "absolute top-0.5 right-0 w-px bg-[var(--color-bevel-shadow-inner)]",
-            selected ? "bottom-[-3px]" : "bottom-0"
+            "bg-bevel-shadow-inner absolute top-0.5 right-0 w-px",
+            selected ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 우측 그림자 - 외부 */}
         <div
           className={twMerge(
-            "absolute top-0.5 -right-px w-px bg-[var(--color-bevel-shadow-outer)]",
-            selected ? "bottom-[-3px]" : "bottom-0"
+            "bg-bevel-shadow-outer absolute top-0.5 -right-px w-px",
+            selected ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 배경 - 메인 바디 */}
-        <div className="absolute top-px right-px bottom-0 left-px z-0 bg-[var(--color-surface)]" />
+        <div className="bg-surface absolute top-px right-px bottom-0 left-px z-0" />
       </div>
       {/* selected일 때 하단 surface 색 줄 - 윈도우와 배경을 잇기 위한 줄 */}
       {selected && (
-        <div className="absolute right-[2px] bottom-[-3px] left-[2px] h-[3px] bg-[var(--color-surface)]" />
+        <div className="bg-surface absolute right-0.5 -bottom-0.75 left-0.5 z-10 h-0.75" />
       )}
-      <span className="relative">{children}</span>
+      <span className="relative z-10 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+        {children}
+      </span>
     </button>
   );
 }

--- a/src/components/Tab/RoundedTab.tsx
+++ b/src/components/Tab/RoundedTab.tsx
@@ -72,11 +72,9 @@ export default function RoundedTab({ children, className, selected, ...rest }: T
   return (
     <button
       type="button"
-      role="tab"
-      aria-selected={selected}
       className={twMerge(
         "relative inline-flex cursor-pointer items-center justify-center",
-        "min-w-0 shrink px-0 py-1 text-xs whitespace-nowrap",
+        "min-w-0 shrink px-0 py-1 text-xs",
         className
       )}
       {...rest}
@@ -90,7 +88,7 @@ export default function RoundedTab({ children, className, selected, ...rest }: T
         {/* 좌측 하이라이트 - 내부 */}
         <div
           className={twMerge(
-            "bg-bevel-light-outer absolute top-0.5 left-0 w-px",
+            "bg-bevel-light-inner absolute top-0.5 left-0 w-px",
             selected ? "-bottom-0.75" : "bottom-0"
           )}
         />


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요
- rounded 탭 컴포넌트를 구현했습니다
- 하단이 잘려있고 상단 모서리가 둥근 형태의 탭으로, div 레이어를 쌓아서 bevel 효과를 구현했습니다.
## ✅ 관련 이슈

- Close #35 

## 🛠️ 상세 작업 내용

- [x] div 레이어들을 absolute로 배치하여 rounded bevel 효과 구현
  - 상단 하이라이트 (내부/외부)
  - 좌측 하이라이트 (내부/외부)
  - 우측 그림자 (내부/외부)
  - 배경 메인 바디

- [x] `selected` prop을 통한 선택 상태 지원
  - selected 탭은 하단에 surface 색의 3px 높이 줄 추가
  - 좌우 하이라이트와 그림자가 3px 아래로 확장되어 윈도우와 연결

- [x] 반응형 동작
  - 화면이 줄어들면 탭 너비 자동 축소
  - 긴 텍스트는 ellipsis로 표시
  - 텍스트 줄바꿈 방지

## ⚠️ 주의 사항 (옵션)

<!-- 다른 작업물에 영향을 줄 수 있는 변화가 있다면 적어주세요 -->

## 📸 스크린샷 (옵션)

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->
<img width="643" height="237" alt="image" src="https://github.com/user-attachments/assets/dd862807-e516-42a9-b8c4-2647282de553" />
<img width="645" height="232" alt="image" src="https://github.com/user-attachments/assets/8241e249-a421-418c-b12b-94592b843431" />


## 👥 리뷰 확인 사항 (옵션)

<!-- 코드 리뷰 시에 특별히 확인해야 하는 사항이 있으면 적어주세요 -->
<!-- 예시: 제가 지정한 타입 정의가 적절한지 확인 부탁드립니다 -->
- selected 조건 cva로 분리할까 하다가 너무 작은 부분이라 그냥 테일윈드로 구현했습니다.