### PR TITLE
[#30] feat(shortcut): Shortcut 컴포넌트 추가 및 WindowApp 타입 정의

### DIFF
--- a/src/assets/icons/friends.svg
+++ b/src/assets/icons/friends.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Multiple-User--Streamline-Pixel">
+  <desc>
+    Multiple User Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>multiple-user</title>
+  <g>
+    <path d="M30.48 18.285H32v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M27.43 16.765h3.05v1.52h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M27.43 13.715h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m22.86 15.245 0 -3.05 -1.52 0 0 -1.53 -1.53 0 0 -3.04 1.53 0 0 -1.53 6.09 0 0 1.53 1.52 0 0 6.09 1.53 0 0 -9.14 -1.53 0 0 -1.53 -1.52 0 0 -1.52 -6.09 0 0 1.52 -1.53 0 0 1.53 -1.52 0 0 4.57 -4.57 0 0 -4.57 -1.53 0 0 -1.53 -1.52 0 0 -1.52 -6.1 0 0 1.52 -1.52 0 0 1.53 -1.52 0 0 9.14 1.52 0 0 -6.09 1.52 0 0 -1.53 6.1 0 0 1.53 1.52 0 0 3.04 -1.52 0 0 1.53 -1.52 0 0 3.05 -4.58 0 0 1.52 4.58 0 0 6.09 1.52 0 0 -7.61 1.52 0 0 -1.53 7.62 0 0 1.53 1.53 0 0 7.61 1.52 0 0 -6.09 4.57 0 0 -1.52 -4.57 0z" fill="currentColor" stroke-width="1"></path>
+    <path d="M24.38 28.955h1.53v1.52h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.86 27.435h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M19.81 25.905h3.05v1.53h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M19.81 22.855h1.53v1.53h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M18.29 16.765h1.52v3.05h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.19 24.385h7.62v1.52h-7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M13.72 21.335h4.57v1.52h-4.57Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.19 16.765h1.53v3.05h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M10.67 22.855h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.15 25.905h3.04v1.53H9.15Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M7.62 27.435h1.53v1.52H7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.1 28.955h1.52v1.52H6.1Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M3.05 13.715h1.52v1.53H3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M1.53 16.765h3.04v1.52H1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M0 18.285h1.53v1.53H0Z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/assets/icons/gallery.svg
+++ b/src/assets/icons/gallery.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Interface-Essential-Paginate-Filter-Picture--Streamline-Pixel">
+  <desc>
+    Interface Essential Paginate Filter Picture Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>interface-essential-paginate-filter-picture</title>
+  <g>
+    <path d="M29.71 2.28h1.53v22.86h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m6.85 25.14 0 1.52 1.53 0 0 1.53 1.52 0 0 -1.53 3.05 0 0 1.53 1.52 0 0 -1.53 3.05 0 0 1.53 1.52 0 0 -1.53 3.05 0 0 1.53 1.53 0 0 -1.53 1.52 0 0 1.53 -1.52 0 0 1.52 -3.05 0 0 -1.52 -1.53 0 0 1.52 -3.04 0 0 -1.52 -1.53 0 0 1.52 -3.04 0 0 -1.52 -1.53 0 0 1.52 -3.05 0 0 -1.52 -1.52 0 0 1.52 -3.05 0 0 1.53 22.86 0 0 -1.53 1.52 0 0 -3.05 3.05 0 0 -1.52 -22.86 0z" fill="currentColor" stroke-width="1"></path>
+    <path d="m26.66 12.95 -3.04 0 0 1.52 3.04 0 0 4.58 1.53 0 0 -13.72 -1.53 0 0 7.62z" fill="currentColor" stroke-width="1"></path>
+    <path d="m23.62 17.52 -1.53 0 0 1.53 -12.19 0 0 1.52 16.76 0 0 -1.52 -3.04 0 0 -1.53z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.09 6.85h3.05V9.9h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.09 14.47h1.53V16h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M20.57 16h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M19.04 14.47h1.53V16h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M17.52 12.95h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M14.47 11.43h3.05v1.52h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.95 12.95h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M11.43 14.47h1.52V16h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.9 3.81h16.76v1.52H9.9Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m11.43 17.52 0 -1.52 -1.53 0 0 -10.67 -1.52 0 0 13.72 1.52 0 0 -1.53 1.53 0z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.85 0.76h22.86v1.52H6.85Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M3.81 26.66h1.52v1.53H3.81Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m3.81 26.66 0 -1.52 -1.53 0 0 -3.05 1.53 0 0 -1.52 -1.53 0 0 -3.05 1.53 0 0 -1.52 -1.53 0 0 -3.05 1.53 0 0 -1.52 -1.53 0 0 -3.05 1.53 0 0 -1.53 1.52 0 0 1.53 -1.52 0 0 1.52 1.52 0 0 3.05 -1.52 0 0 1.52 1.52 0 0 3.05 -1.52 0 0 1.53 1.52 0 0 3.04 -1.52 0 0 1.53 1.52 0 0 1.52 1.52 0 0 -22.86 -1.52 0 0 3.05 -3.05 0 0 1.52 -1.52 0 0 22.86 1.52 0 0 -3.05 1.53 0z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/assets/icons/guestbook.svg
+++ b/src/assets/icons/guestbook.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Romance-Love-Letter-Open--Streamline-Pixel">
+  <desc>
+    Romance Love Letter Open Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>romance-love-letter-open</title>
+  <g>
+    <path d="m30.47 15.23 -1.52 0 0 1.53 1.52 0 0 12.19 1.53 0 0 -16.76 -1.53 0 0 3.04z" fill="currentColor" stroke-width="1"></path>
+    <path d="M28.95 28.95h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M28.95 10.66h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m27.43 28.95 -1.53 0 0 1.52 -19.81 0 0 -1.52 -1.52 0 0 1.52 -1.53 0 0 1.53 25.91 0 0 -1.53 -1.52 0 0 -1.52z" fill="currentColor" stroke-width="1"></path>
+    <path d="M24.38 27.42h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.85 25.9h1.53v1.52h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.85 18.28h3.05v1.53h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M21.33 24.38h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M19.81 22.85h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M19.81 19.81h3.04v1.52h-3.04Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M19.81 1.52h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m19.81 10.66 -3.05 0 0 1.53 -1.52 0 0 -1.53 -3.05 0 0 1.53 -1.53 0 0 3.04 1.53 0 0 1.53 1.52 0 0 1.52 1.53 0 0 1.53 1.52 0 0 -1.53 1.52 0 0 -1.52 1.53 0 0 -1.53 1.52 0 0 -3.04 -1.52 0 0 -1.53z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.19 21.33h7.62v1.52h-7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.19 0h7.62v1.52h-7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M10.66 22.85h1.53v1.53h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.14 19.81h3.05v1.52H9.14Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M10.66 1.52h1.53v1.52h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.14 24.38h1.52v1.52H9.14Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M7.62 25.9h1.52v1.52H7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.09 18.28h3.05v1.53H6.09Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.09 27.42h1.53v1.53H6.09Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m4.57 16.76 -1.53 0 0 1.52 3.05 0 0 -12.19 19.81 0 0 12.19 3.05 0 0 -1.52 -1.52 0 0 -6.1 1.52 0 0 -1.52 -1.52 0 0 -4.57 -4.58 0 0 -1.53 -1.52 0 0 1.53 -10.67 0 0 -1.53 -1.52 0 0 1.53 -4.57 0 0 4.57 -1.53 0 0 1.52 1.53 0 0 6.1z" fill="currentColor" stroke-width="1"></path>
+    <path d="M1.52 28.95h1.52v1.52H1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M1.52 10.66h1.52v1.53H1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m1.52 16.76 1.52 0 0 -1.53 -1.52 0 0 -3.04 -1.52 0 0 16.76 1.52 0 0 -12.19z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/assets/icons/home.svg
+++ b/src/assets/icons/home.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Building-Real-Eastate-Sign-House-1--Streamline-Pixel">
+  <desc>
+    Building Real Eastate Sign House 1 Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>building-real-eastate-sign-house-1</title>
+  <g>
+    <path d="M30.48 10.66H32v18.29h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M28.96 28.95h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M28.96 9.14h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.15 30.47h19.81V32H9.15Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M32 4.57V3.04h-4.57V1.52h-1.52v1.52H13.72V1.52h-1.53v1.52H4.58V1.52H3.05V32h1.53V4.57h7.61v3.05H9.15v1.52h19.81V7.62h-1.53V4.57Zm-6.09 3.05H13.72V4.57h12.19Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.19 27.43h6.1v-4.58h1.52v4.58h6.1v-6.1h1.52v-3.05h-1.52v-1.52h-1.52v-1.52h-1.53v-1.53h-1.52v-1.52h-1.53v-1.53h-1.52v1.53h-1.52v1.52h-1.53v1.53h-1.52v1.52h-1.53v1.52h-1.52v3.05h1.52Zm1.53 -7.62h1.52v-1.53h1.53v-1.52h1.52v-1.52h1.52v1.52h1.53v1.52h1.52v1.53h1.53v6.09h-3.05v-4.57h-4.57v4.57h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M7.62 28.95h1.53v1.52H7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M7.62 9.14h1.53v1.52H7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.1 10.66h1.52v18.29H6.1Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M1.53 0h1.52v1.52H1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M0 1.52h1.53V32H0Z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/assets/icons/settings.svg
+++ b/src/assets/icons/settings.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Interface-Essential-Cog-Browser--Streamline-Pixel">
+  <desc>
+    Interface Essential Cog Browser Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>interface-essential-cog-browser</title>
+  <g>
+    <g>
+      <path d="m30.47 6.1 -28.95 0 0 -4.57 -1.52 0 0 28.95 1.52 0 0 -22.86 28.95 0 0 22.86 1.53 0 0 -28.95 -1.53 0 0 4.57z" fill="currentColor" stroke-width="1"></path>
+      <path d="M1.52 30.48h28.95V32H1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M22.86 22.86h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="m22.86 18.29 1.52 0 0 1.52 -1.52 0 0 1.53 3.04 0 0 -4.58 -3.04 0 0 1.53z" fill="currentColor" stroke-width="1"></path>
+      <path d="M22.86 13.72h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M21.33 24.38h1.53v1.53h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M21.33 21.34h1.53v1.52h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M21.33 15.24h1.53v1.52h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M21.33 12.19h1.53v1.53h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M19.81 25.91h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M19.81 10.67h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M18.28 24.38h1.53v1.53h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M18.28 16.76h1.53v4.58h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M18.28 12.19h1.53v1.53h-1.53Z" fill="currentColor" stroke-width="1"></path>
+      <path d="m16.76 27.43 -1.52 0 0 -1.52 -1.53 0 0 3.04 4.57 0 0 -3.04 -1.52 0 0 1.52z" fill="currentColor" stroke-width="1"></path>
+      <path d="M13.71 21.34h4.57v1.52h-4.57Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M13.71 15.24h4.57v1.52h-4.57Z" fill="currentColor" stroke-width="1"></path>
+      <path d="m15.24 10.67 1.52 0 0 1.52 1.52 0 0 -3.04 -4.57 0 0 3.04 1.53 0 0 -1.52z" fill="currentColor" stroke-width="1"></path>
+      <path d="M12.19 24.38h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M12.19 16.76h1.52v4.58h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M12.19 12.19h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M10.67 25.91h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M10.67 10.67h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M9.14 24.38h1.53v1.53H9.14Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M9.14 21.34h1.53v1.52H9.14Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M9.14 15.24h1.53v1.52H9.14Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M9.14 12.19h1.53v1.53H9.14Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M9.14 3.05h1.53v1.52H9.14Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M7.62 22.86h1.52v1.52H7.62Z" fill="currentColor" stroke-width="1"></path>
+      <path d="m7.62 19.81 0 -1.52 1.52 0 0 -1.53 -3.05 0 0 4.58 3.05 0 0 -1.53 -1.52 0z" fill="currentColor" stroke-width="1"></path>
+      <path d="M7.62 13.72h1.52v1.52H7.62Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M6.09 3.05h1.53v1.52H6.09Z" fill="currentColor" stroke-width="1"></path>
+      <path d="M3.05 3.05h1.52v1.52H3.05Z" fill="currentColor" stroke-width="1"></path>
+    </g>
+    <path d="M1.52 0h28.95v1.53H1.52Z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/components/Shortcut/Shortcut.tsx
+++ b/src/components/Shortcut/Shortcut.tsx
@@ -1,0 +1,68 @@
+import { twMerge } from "tailwind-merge";
+
+import type { WindowApp } from "@/types/window-app.type.ts";
+
+interface ShortcutProps {
+  Icon: WindowApp["icon"];
+  caption: WindowApp["caption"];
+  isSelected?: boolean;
+  isFocused?: boolean;
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+}
+
+/**
+ * 바로가기 컴포넌트
+ *
+ * @component
+ * @example
+ * ```tsx
+ * import Shortcut from "@/components/Shortcut/Shortcut";
+ * import { WINDOW_APP } from "@/types/window-app.type";
+ *
+ * <Shortcut
+ *   Icon={WINDOW_APP.HOME.icon}
+ *   caption={WINDOW_APP.HOME.caption
+ * />
+ * ```
+ */
+export default function Shortcut({
+  Icon,
+  caption,
+  isSelected = false,
+  isFocused = false,
+  onClick,
+  onDoubleClick,
+}: ShortcutProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      className={twMerge(
+        "group",
+        "inline-flex min-h-16 min-w-16 flex-col items-center justify-center",
+        "gap-1 px-2 py-2",
+        "text-center"
+      )}
+    >
+      <Icon
+        className={twMerge(
+          "text-text-default",
+          "size-11 md:size-14 lg:size-16",
+          isSelected && "bg-secondary/80"
+        )}
+        aria-hidden="true"
+      />
+      <span
+        className={twMerge(
+          "text-text-default",
+          isSelected && "bg-secondary/80 focus-dotted",
+          isFocused && "focus-dotted"
+        )}
+      >
+        {caption}
+      </span>
+    </button>
+  );
+}

--- a/src/types/window-app.type.ts
+++ b/src/types/window-app.type.ts
@@ -1,0 +1,30 @@
+import Friends from "@/assets/icons/friends.svg?react";
+import Gallery from "@/assets/icons/gallery.svg?react";
+import Guestbook from "@/assets/icons/guestbook.svg?react";
+import Home from "@/assets/icons/home.svg?react";
+import Settings from "@/assets/icons/settings.svg?react";
+
+export const WINDOW_APP = {
+  HOME: {
+    caption: "Home",
+    icon: Home,
+  },
+  GALLERY: {
+    caption: "Gallery",
+    icon: Gallery,
+  },
+  GUESTBOOK: {
+    caption: "Guest Book",
+    icon: Guestbook,
+  },
+  FRIENDS: {
+    caption: "Friends",
+    icon: Friends,
+  },
+  SETTINGS: {
+    caption: "Settings",
+    icon: Settings,
+  },
+} as const;
+
+export type WindowApp = (typeof WINDOW_APP)[keyof typeof WINDOW_APP];


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 바로가기 아이콘인 Shortcut 컴포넌트 추가
- 각 앱별 SVG 아이콘을 import하고, WINDOW_APP 상수 및 WindowApp 타입을 정의

## ✅ 관련 이슈

- Close #30 

## 🛠️ 상세 작업 내용

- [x] Shortcut 컴포넌트 반응형 구현
- [x] friends, gallery, guestbook, home, settings SVG 아이콘 추가
- [x] WINDOW_APP 상수 및 WindowApp 타입 정의
- [x] 타입 및 상수 파일 `@/types/window-app.type.ts` 생성

## 📸 스크린샷

<img width="268" height="105" alt="스크린샷 2025-11-12 04 33 23" src="https://github.com/user-attachments/assets/901ce2e7-8bdc-42b7-9902-e31f8c581a73" />

## 👥 리뷰 확인 사항

선택 상태일 때 색상은 일단 secondary 색상으로 구현했는데, 색상 추천 받습니다 🙃
아이콘 색상은 일단 기본으로 만들었습니다.
이후 바탕화면에 어울리는 색으로 변경 혹은 테마 색상 중 랜덤으로 구현 고민 중입니다.
