### PR TITLE
[#53] feat(taskbar): Taskbar와 TaskbarTab 상태관리와 연동 및 현재 시간 구현

### DIFF
--- a/src/components/os/Taskbar/Taskbar.tsx
+++ b/src/components/os/Taskbar/Taskbar.tsx
@@ -1,20 +1,23 @@
 import React from "react";
 import { twMerge } from "tailwind-merge";
 
+import { useWindowStore } from "@/stores/useWindowStore";
+
 import TaskbarStart from "./TaskbarStart";
 import TaskbarSystemTray from "./TaskbarSystemTray";
+import TaskbarTab from "./TaskbarTab";
 import { taskbar } from "./variants";
 
 export type TaskbarConfig = "default" | "noStartButton" | "noSystemTray" | "minimal";
 
 type TaskbarProps = React.ComponentPropsWithoutRef<"nav"> & {
-  config: TaskbarConfig;
-  children: React.ReactNode;
+  config?: TaskbarConfig;
 };
 
 /**
  * Taskbar 컴포넌트
  *
+ * Zustand와 연동되어 Window Store의 windows를 구독하여 자동으로 탭을 생성합니다.
  * Start 버튼, Tab 버튼들, 시스템 트레이를 포함합니다.
  * config prop으로 표시할 요소를 제어할 수 있습니다.
  * 네비게이션 역할을 하므로 `<nav>` 엘리먼트를 사용합니다.
@@ -26,47 +29,52 @@ type TaskbarProps = React.ComponentPropsWithoutRef<"nav"> & {
  *   - "noSystemTray": 시스템 트레이 없음
  *   - "minimal": Start 버튼과 시스템 트레이 모두 없음 (Tab만 표시)
  * @param {string} [className] - 추가 Tailwind 클래스
- * @param {React.ReactNode} children - TaskbarTab 컴포넌트들
  * @returns {JSX.Element} Nav 엘리먼트
  *
  * @example
  * ```tsx
  * // 기본 구성 (모두 표시)
- * <Taskbar>
- *   <TaskbarTab icon={<Folder size={14} />} text="My Computer" isActive />
- * </Taskbar>
+ * <Taskbar />
  *
  * // Start 버튼 없음
- * <Taskbar config="noStartButton">
- *   <TaskbarTab icon={<Folder size={14} />} text="My Computer" />
- * </Taskbar>
+ * <Taskbar config="noStartButton" />
  *
  * // 시스템 트레이 없음
- * <Taskbar config="noSystemTray">
- *   <TaskbarTab icon={<Folder size={14} />} text="My Computer" />
- * </Taskbar>
+ * <Taskbar config="noSystemTray" />
  *
  * // 최소 구성 (Tab만 표시)
- * <Taskbar config="minimal">
- *   <TaskbarTab icon={<Folder size={14} />} text="My Computer" />
- * </Taskbar>
+ * <Taskbar config="minimal" />
  * ```
  */
-export default function Taskbar({
-  className,
-  config = "default",
-  children,
-  ...rest
-}: TaskbarProps) {
+export default function Taskbar({ className, config = "default", ...rest }: TaskbarProps) {
+  // Taskbar 탭으로 노출할 전체 창 목록
+  const windows = useWindowStore((state) => state.windows);
+  // 현재 포커스된 창의 카테고리
+  const focusedWindowCategory = useWindowStore((state) => state.focusedWindowCategory);
+  // 특정 창으로 포커스를 이동시키는 액션
+  const setFocusWindow = useWindowStore((state) => state.setFocusWindow);
+
   const showStart = config === "default" || config === "noSystemTray";
   const showSystemTray = config === "default" || config === "noStartButton";
+
+  const handleTabClick = (category: string) => {
+    // Taskbar 탭 클릭 시 해당 window로 focus
+    setFocusWindow(category);
+  };
 
   return (
     <nav className={twMerge(taskbar, className)} {...rest}>
       {showStart && <TaskbarStart />}
       <ul className="flex flex-1 items-center gap-1 overflow-hidden">
-        {React.Children.map(children, (child) => (
-          <li className="@container flex max-w-43 min-w-0 flex-1">{child}</li>
+        {windows.map((window) => (
+          <li key={window.category} className="@container flex max-w-43 min-w-0 flex-1">
+            <TaskbarTab
+              icon={window.icon}
+              title={window.title}
+              isFocused={window.category === focusedWindowCategory}
+              onClick={() => handleTabClick(window.category)}
+            />
+          </li>
         ))}
       </ul>
       {showSystemTray && <TaskbarSystemTray />}

--- a/src/components/os/Taskbar/TaskbarSystemTray.tsx
+++ b/src/components/os/Taskbar/TaskbarSystemTray.tsx
@@ -33,8 +33,8 @@ export default function TaskbarSystemTray({ className, ...rest }: TaskbarSystemT
     };
   }, []);
 
-  const formattedTime = currentTime.format("HH:mm");
-  const isoTime = currentTime.format("YYYY-MM-DDTHH:mm:ssZ");
+  const formattedTime = currentTime.format("h:mm A");
+  const isoTime = currentTime.toISOString();
 
   return (
     <div className={twMerge(taskbarSystemTray, className)} {...rest}>

--- a/src/components/os/Taskbar/TaskbarSystemTray.tsx
+++ b/src/components/os/Taskbar/TaskbarSystemTray.tsx
@@ -24,12 +24,29 @@ export default function TaskbarSystemTray({ className, ...rest }: TaskbarSystemT
   const [currentTime, setCurrentTime] = useState(dayjs());
 
   useEffect(() => {
-    const timer = setInterval(() => {
+    const updateTime = () => {
       setCurrentTime(dayjs());
-    }, 1000);
+    };
+
+    // 즉시 한 번 업데이트
+    updateTime();
+
+    // 다음 분 경계에 맞춰서 1분 간격으로 갱신
+    const now = dayjs();
+    const msUntilNextMinute = (60 - now.second()) * 1000 - now.millisecond();
+
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const timeoutId = setTimeout(() => {
+      updateTime();
+      intervalId = setInterval(updateTime, 60000);
+    }, msUntilNextMinute);
 
     return () => {
-      clearInterval(timer);
+      clearTimeout(timeoutId);
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
     };
   }, []);
 

--- a/src/components/os/Taskbar/TaskbarSystemTray.tsx
+++ b/src/components/os/Taskbar/TaskbarSystemTray.tsx
@@ -1,4 +1,3 @@
-import { Volume2 } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 import { taskbarSystemTray } from "./variants";
@@ -22,7 +21,6 @@ type TaskbarSystemTrayProps = React.ComponentPropsWithoutRef<"div">;
 export default function TaskbarSystemTray({ className, ...rest }: TaskbarSystemTrayProps) {
   return (
     <div className={twMerge(taskbarSystemTray, className)} {...rest}>
-      <Volume2 size={14} className="shrink-0" />
       <time className="whitespace-nowrap" dateTime="">
         {/* 시간 표시 영역 */}
         12:00

--- a/src/components/os/Taskbar/TaskbarSystemTray.tsx
+++ b/src/components/os/Taskbar/TaskbarSystemTray.tsx
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 import { taskbarSystemTray } from "./variants";
@@ -7,7 +9,7 @@ type TaskbarSystemTrayProps = React.ComponentPropsWithoutRef<"div">;
 /**
  * Taskbar 시스템 트레이 컴포넌트
  *
- * 내부에 스피커 아이콘과 시간 표시 영역이 포함되어 있습니다.
+ * 내부에 시간 표시 영역이 포함되어 있습니다.
  *
  * @component
  * @param {string} [className] - 추가 Tailwind 클래스
@@ -19,11 +21,25 @@ type TaskbarSystemTrayProps = React.ComponentPropsWithoutRef<"div">;
  * ```
  */
 export default function TaskbarSystemTray({ className, ...rest }: TaskbarSystemTrayProps) {
+  const [currentTime, setCurrentTime] = useState(dayjs());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentTime(dayjs());
+    }, 1000);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, []);
+
+  const formattedTime = currentTime.format("HH:mm");
+  const isoTime = currentTime.format("YYYY-MM-DDTHH:mm:ssZ");
+
   return (
     <div className={twMerge(taskbarSystemTray, className)} {...rest}>
-      <time className="whitespace-nowrap" dateTime="">
-        {/* 시간 표시 영역 */}
-        12:00
+      <time className="whitespace-nowrap" dateTime={isoTime}>
+        {formattedTime}
       </time>
     </div>
   );

--- a/src/components/os/Taskbar/TaskbarTab.tsx
+++ b/src/components/os/Taskbar/TaskbarTab.tsx
@@ -24,7 +24,7 @@ interface TaskbarTabProps {
  *
  * @component
  * @param {ReactNode} icon - 아이콘을 나타내는 React 노드
- * @param {string} text - 탭에 표시할 텍스트
+ * @param {string} title - 탭에 표시할 윈도우 제목
  * @param {boolean} [isFocused=false] - focus 상태 (true면 pressed, false면 neutral)
  * @param {string} [className] - 추가 Tailwind 클래스
  * @param {React.MouseEventHandler<HTMLButtonElement>} [onClick] - 클릭 이벤트 핸들러
@@ -32,7 +32,7 @@ interface TaskbarTabProps {
  *
  * @example
  * ```tsx
- * <TaskbarTab icon={<Folder size={14} />} text="My Computer" isFocused />
+ * <TaskbarTab icon={<Folder size={14} />} title="My Computer" isFocused />
  * ```
  */
 export default function TaskbarTab({

--- a/src/components/os/Taskbar/TaskbarTab.tsx
+++ b/src/components/os/Taskbar/TaskbarTab.tsx
@@ -7,8 +7,8 @@ import { taskbarTab } from "./variants";
 
 interface TaskbarTabProps {
   icon: ReactNode;
-  text: string;
-  isActive?: boolean;
+  title: string;
+  isFocused?: boolean;
   className?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
@@ -17,7 +17,7 @@ interface TaskbarTabProps {
  * Taskbar Tab 컴포넌트
  *
  * Tab을 구현한 컴포넌트입니다.
- * active된 윈도우의 상태를 감지하여 pressed/neutral 상태를 표시합니다.
+ * focus된 윈도우의 상태를 감지하여 pressed/neutral 상태를 표시합니다.
  * 탭 너비가 44px 이하일 때는 아이콘만 표시하고, 그 이상일 때는 텍스트도 표시합니다.
  * CSS Container Queries를 사용하여 JavaScript 없이 동작합니다.
  * Button 컴포넌트를 기반으로 구현되었습니다.
@@ -25,20 +25,20 @@ interface TaskbarTabProps {
  * @component
  * @param {ReactNode} icon - 아이콘을 나타내는 React 노드
  * @param {string} text - 탭에 표시할 텍스트
- * @param {boolean} [isActive=false] - 활성 상태 (true면 pressed, false면 neutral)
+ * @param {boolean} [isFocused=false] - focus 상태 (true면 pressed, false면 neutral)
  * @param {string} [className] - 추가 Tailwind 클래스
  * @param {React.MouseEventHandler<HTMLButtonElement>} [onClick] - 클릭 이벤트 핸들러
  * @returns {JSX.Element} Button 컴포넌트
  *
  * @example
  * ```tsx
- * <TaskbarTab icon={<Folder size={14} />} text="My Computer" isActive />
+ * <TaskbarTab icon={<Folder size={14} />} text="My Computer" isFocused />
  * ```
  */
 export default function TaskbarTab({
   icon,
-  text,
-  isActive = false,
+  title,
+  isFocused = false,
   className,
   onClick,
 }: TaskbarTabProps) {
@@ -46,16 +46,16 @@ export default function TaskbarTab({
     <Button
       size="sm"
       composition="iconText"
-      state={isActive ? "pressed" : "neutral"}
+      state={isFocused ? "pressed" : "neutral"}
       width="auto"
       className={twMerge(taskbarTab, className)}
       onClick={onClick}
     >
       <span className="flex overflow-hidden">
         <span className="shrink-0">{icon}</span>
-        {text && (
-          <span className="min-w-0 flex-1 truncate @max-[44px]:hidden" title={text}>
-            {text}
+        {title && (
+          <span className="min-w-0 flex-1 truncate @max-[44px]:hidden" title={title}>
+            {title}
           </span>
         )}
       </span>

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -27,7 +27,7 @@ interface WindowStore {
 
   /**
    * Store에서 Window를 제거합니다. 제거된 Window가 focus였을 경우,
-   * focusedWindowCategory를 undefined로 설정합니다.
+   * focusedWindowCategory를 null으로 설정합니다.
    * 다른 Window로 자동 focus를 옮기지 않습니다 (사용자가 직접 선택하도록).
    * @param category - 제거할 Window의 카테고리
    */
@@ -61,7 +61,7 @@ export const useWindowStore = create<WindowStore>()(
         const index = state.windows.findIndex((w) => w.category === category);
         if (index !== -1) {
           state.windows.splice(index, 1);
-          // 제거된 window가 focused였으면 focusedWindowCategory를 undefined로 설정
+          // 제거된 window가 focused였으면 focusedWindowCategory를 null으로 설정
           // 다른 window로 자동 focus를 옮기지 않음 (사용자가 직접 선택하도록)
           if (state.focusedWindowCategory === category) {
             state.focusedWindowCategory = null;


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 태스크바 컴포넌트를 전역 상태랑 연결했습니다
- 시스템 트레이의 시간을 현재 시간과 동기화하였습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #53 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] Taskbar, TaskbarTab이 useWindowStore의 상태를 구독하도록 수정
- [x] active로 되어있던 프롭을 focused로 변경
- [x]  JSDoc 명칭(active->isFocused, text->title) 정리

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="1891" height="66" alt="image" src="https://github.com/user-attachments/assets/67fb900e-bf52-478d-b77d-4c9f51f23898" />


## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
시간은 타이머 기반으로 갱신하도록 짰습니다
