### PR TITLE
[#66] feat(minihome): MiniHome 페이지 및 탭 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@supabase/supabase-js": "^2.79.0",
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.90.6",
@@ -1383,6 +1384,32 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1445,6 +1472,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1605,6 +1647,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1619,6 +1692,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@supabase/supabase-js": "^2.79.0",
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.90.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
 import { Routes, Route, Navigate } from "react-router";
 
+import SignInPage from "@/pages/auth/sign-in/SignInPage";
+import SignUpPage from "@/pages/auth/sign-up/SignUpPage";
 import MockMainPage from "@/pages/MockMainPage";
-
-import SignInPage from "./pages/auth/sign-in/SignInPage";
-import SignUpPage from "./pages/auth/sign-up/SignUpPage";
 
 export default function App() {
   return (

--- a/src/components/os/Tab/RoundedTab.tsx
+++ b/src/components/os/Tab/RoundedTab.tsx
@@ -2,7 +2,8 @@ import { twMerge } from "tailwind-merge";
 
 interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
   children: React.ReactNode;
-  selected?: boolean;
+  isActive?: boolean;
+  onClick?: () => void;
 }
 
 /**
@@ -68,7 +69,7 @@ interface TabProps extends React.ComponentPropsWithoutRef<"button"> {
  * </div>
  * ```
  */
-export default function RoundedTab({ children, className, selected, ...rest }: TabProps) {
+export default function RoundedTab({ children, onClick, className, isActive, ...rest }: TabProps) {
   return (
     <button
       type="button"
@@ -82,45 +83,45 @@ export default function RoundedTab({ children, className, selected, ...rest }: T
       {/* 레이어 컨테이너 - 모든 레이어를 묶는 기준 컨테이너 */}
       <div className="absolute top-px right-px bottom-0 left-px">
         {/* 상단 하이라이트 - 내부 */}
-        <div className="bg-bevel-light-inner absolute top-0 right-0.25 left-0.25 h-px" />
+        <div className="bg-bevel-light-inner absolute top-0 right-px left-px h-px" />
         {/* 상단 하이라이트 - 외부 */}
         <div className="bg-bevel-light-outer absolute -top-px right-0.5 left-0.5 h-px" />
         {/* 좌측 하이라이트 - 내부 */}
         <div
           className={twMerge(
             "bg-bevel-light-inner absolute top-0.5 left-0 w-px",
-            selected ? "-bottom-0.75" : "bottom-0"
+            isActive ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 좌측 하이라이트 - 외부 */}
         <div
           className={twMerge(
             "bg-bevel-light-outer absolute top-0.5 -left-px w-px",
-            selected ? "-bottom-0.75" : "bottom-0"
+            isActive ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 우측 그림자 - 내부 */}
         <div
           className={twMerge(
             "bg-bevel-shadow-inner absolute top-0.5 right-0 w-px",
-            selected ? "-bottom-0.75" : "bottom-0"
+            isActive ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 우측 그림자 - 외부 */}
         <div
           className={twMerge(
             "bg-bevel-shadow-outer absolute top-0.5 -right-px w-px",
-            selected ? "-bottom-0.75" : "bottom-0"
+            isActive ? "-bottom-0.75" : "bottom-0"
           )}
         />
         {/* 배경 - 메인 바디 */}
         <div className="bg-surface absolute top-px right-px bottom-0 left-px z-0" />
       </div>
-      {/* selected일 때 하단 surface 색 줄 - 윈도우와 배경을 잇기 위한 줄 */}
-      {selected && (
+      {/* isActive일 때 하단 surface 색 줄 - 윈도우와 배경을 잇기 위한 줄 */}
+      {isActive && (
         <div className="bg-surface absolute right-0.5 -bottom-0.75 left-0.5 z-10 h-0.75" />
       )}
-      <span className="relative z-10 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+      <span className="relative min-w-0 overflow-hidden px-2 text-ellipsis whitespace-nowrap">
         {children}
       </span>
     </button>

--- a/src/components/window/Window/Content.tsx
+++ b/src/components/window/Window/Content.tsx
@@ -1,9 +1,0 @@
-import { Activity, type ReactNode } from "react";
-
-export default function Content({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <Activity>{children}</Activity>;
-    </>
-  );
-}

--- a/src/components/window/Window/Window.tsx
+++ b/src/components/window/Window/Window.tsx
@@ -23,7 +23,6 @@ export default function Window({
       <Dialog.Portal container={ref.current}>
         <Dialog.Content onInteractOutside={(e) => e.preventDefault()} asChild>
           <section
-            role="application"
             className={twMerge(
               "bevel-default absolute inline-flex h-fit w-fit flex-col p-[3px] focus:outline-none",
               // TODO: 가변 사이즈 변경

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,0 +1,34 @@
+import * as Tabs from "@radix-ui/react-tabs";
+import { Activity, useState } from "react";
+
+import RoundedTab from "@/components/os/Tab/RoundedTab";
+import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
+
+export default function MiniHome({ tab = "Home" }: { tab?: MiniHomeTabs }) {
+  const [activeTab, setActiveTab] = useState<MiniHomeTabs>(tab);
+
+  return (
+    <Tabs.Root value={activeTab} onValueChange={(value) => setActiveTab(value as MiniHomeTabs)}>
+      <Tabs.List aria-label="미니홈 탭">
+        {Object.values(MINIHOME_TABS).map((v) => (
+          <Tabs.Trigger key={v} value={v} asChild>
+            <RoundedTab isActive={activeTab === v}>{v}</RoundedTab>
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+      {/* TODO: 컴포넌트 주입해주시면 됩니다. */}
+      <Tabs.Content value={MINIHOME_TABS.HOME}>
+        <Activity>홈</Activity>
+      </Tabs.Content>
+      <Tabs.Content value={MINIHOME_TABS.GALLERY}>
+        <Activity>사진첩</Activity>
+      </Tabs.Content>
+      <Tabs.Content value={MINIHOME_TABS.MEMO}>
+        <Activity>메모장</Activity>
+      </Tabs.Content>
+      <Tabs.Content value={MINIHOME_TABS.GUESTBOOK}>
+        <Activity>방명록</Activity>
+      </Tabs.Content>
+    </Tabs.Root>
+  );
+}

--- a/src/types/minihome.types.ts
+++ b/src/types/minihome.types.ts
@@ -1,0 +1,8 @@
+export const MINIHOME_TABS = {
+  HOME: "Home",
+  GALLERY: "Gallery",
+  MEMO: "Memo",
+  GUESTBOOK: "Guest Book",
+} as const;
+
+export type MiniHomeTabs = (typeof MINIHOME_TABS)[keyof typeof MINIHOME_TABS];


### PR DESCRIPTION
## 📖 개요

MiniHome 페이지 및 탭 기능 구현

## ✅ 관련 이슈

- Close #66 

## 🛠️ 상세 작업 내용

- [x] `@radix-ui/react-tabs` 디펜던시 추가
- [x] `App.tsx`에 import @ 알리아스 추가
- [x] `stores` 폴더의 불필요한 .gitkeep 삭제
- [x] `pages` 폴더에 `MiniHome.tsx` 추가 및 탭 기능 구현
- [x] `Window` 컴포넌트의 불필요한 role 삭제
- [x] `RoundedTab` 컴포넌트의 seleted -> isActive 이름 변경 

## 📸 스크린샷

<img width="652" height="527" alt="스크린샷 2025-11-14 02 25 22" src="https://github.com/user-attachments/assets/aaf42377-0ada-40b6-afd0-a376a2129374" />

## ⚠️ 주의 사항

`pages`에 있는 `MiniHome.tsx`에 각 탭에 해당하는 컴포넌트 import 해주시면 됩니다.

## 👥 리뷰 확인 사항

바탕화면에서 미니홈피를 불러올 때 tab으로 원하는 값을 넘겨주면 해당 탭으로 바로 뜹니다.
```tsx
<MiniHome tab="Guest Book" />
```
