### PR TITLE
[#67] feat(os): 메인 페이지 윈도우 컴포넌트 연동

### DIFF
--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -2,8 +2,8 @@ import { useRef, useState } from "react";
 
 import Shortcut from "@/components/os/Shortcut/Shortcut";
 import Taskbar from "@/components/os/Taskbar/Taskbar";
-// import Window from "@/components/window/Window/Window";
-// import MiniHome from "@/pages/minihome/MiniHome";
+import Window from "@/components/window/Window/Window";
+import MiniHome from "@/pages/minihome/MiniHome";
 import { useWindowStore } from "@/stores/useWindowStore";
 import { WINDOW_APP } from "@/types/window-app.type";
 
@@ -19,7 +19,7 @@ const DESKTOP_SHORTCUTS = [
 
 export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);
-  const { runWindow } = useWindowStore();
+  const { windows, runWindow, closeWindow } = useWindowStore();
   const [selectedShortcutCategory, setSelectedShortcutCategory] = useState<string | null>(null);
   const [focusedShortcutCategory, setFocusedShortcutCategory] = useState<string | null>(null);
 
@@ -72,7 +72,42 @@ export default function OsMain() {
             </li>
           ))}
         </ul>
-        {/* TODO: 윈도우 렌더링 구현 */}
+        {/* 윈도우 렌더링 */}
+        {windows.map((window) => {
+          // category별로 다른 컴포넌트 렌더링
+          const renderWindowContent = () => {
+            switch (window.category) {
+              case "home":
+                return <MiniHome />;
+              case "gallery":
+                return <div>Gallery (구현 예정)</div>;
+              case "memo":
+                return <div>Memo (구현 예정)</div>;
+              case "guestbook":
+                return <div>Guest Book (구현 예정)</div>;
+              case "friends":
+                return <div>Friends (구현 예정)</div>;
+              case "settings":
+                return <div>Settings (구현 예정)</div>;
+              default:
+                return null;
+            }
+          };
+
+          return (
+            <Window
+              key={window.category}
+              ref={ref}
+              open
+              buttons="all"
+              onClose={() => closeWindow(window.category)}
+              title={window.title}
+              icon={window.icon}
+            >
+              {renderWindowContent()}
+            </Window>
+          );
+        })}
       </div>
       {/* 태스크바 영역 */}
       <Taskbar />

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -4,32 +4,10 @@ import type { ComponentType } from "react";
 import Shortcut from "@/components/os/Shortcut/Shortcut";
 import Taskbar from "@/components/os/Taskbar/Taskbar";
 import Window from "@/components/window/Window/Window";
-import MiniHome from "@/pages/minihome/MiniHome";
 import { useWindowStore } from "@/stores/useWindowStore";
-import { WINDOW_APP } from "@/types/window-app.type";
+import { WINDOW_APP, type WindowApp } from "@/types/window-app.type";
 
-// 바탕화면에 표시될 바로가기 목록
-const DESKTOP_SHORTCUTS = [
-  { category: "home", config: WINDOW_APP.HOME },
-  { category: "gallery", config: WINDOW_APP.GALLERY },
-  { category: "memo", config: WINDOW_APP.MEMO },
-  { category: "guestbook", config: WINDOW_APP.GUESTBOOK },
-  { category: "friends", config: WINDOW_APP.FRIENDS },
-  { category: "settings", config: WINDOW_APP.SETTINGS },
-] as const;
-
-function createPlannedComponent() {
-  return () => <div>(구현 예정)</div>;
-}
-
-const WINDOW_COMPONENT_MAP: Record<string, ComponentType> = {
-  home: MiniHome,
-  gallery: createPlannedComponent(),
-  memo: createPlannedComponent(),
-  guestbook: createPlannedComponent(),
-  friends: createPlannedComponent(),
-  settings: createPlannedComponent(),
-};
+const WINDOW_CONFIGS: WindowApp[] = Object.values(WINDOW_APP);
 
 export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);
@@ -51,7 +29,7 @@ export default function OsMain() {
   const handleShortcutDoubleClick = (
     category: string,
     title: string,
-    IconComponent: React.ComponentType
+    IconComponent: ComponentType
   ) => {
     runWindow({
       category,
@@ -73,23 +51,23 @@ export default function OsMain() {
           className="grid h-full w-full auto-cols-[80px] grid-flow-col grid-rows-[repeat(auto-fill,100px)] content-start gap-4"
           aria-label="바로가기"
         >
-          {DESKTOP_SHORTCUTS.map(({ category, config }) => (
+          {WINDOW_CONFIGS.map(({ category, icon, caption }) => (
             <Shortcut
               key={category}
-              Icon={config.icon}
-              caption={config.caption}
+              Icon={icon}
+              caption={caption}
               isSelected={selectedShortcutCategory === category}
               isFocused={focusedShortcutCategory === category}
               onFocus={() => handleShortcutFocus(category)}
               onBlur={handleShortcutBlur}
-              onDoubleClick={() => handleShortcutDoubleClick(category, config.caption, config.icon)}
+              onDoubleClick={() => handleShortcutDoubleClick(category, caption, icon)}
             />
           ))}
         </div>
         {/* 윈도우 렌더링 */}
         {windows.map((window) => {
-          // 카테고리에 맞는 컴포넌트를 맵에서 찾아 해당 창에 렌더링
-          const WindowContent = WINDOW_COMPONENT_MAP[window.category];
+          const windowConfig = WINDOW_CONFIGS.find((config) => config.category === window.category);
+          const WindowContent = windowConfig?.component;
           if (!WindowContent) return null;
           return (
             <Window

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -74,7 +74,7 @@ export default function OsMain() {
         </ul>
         {/* 윈도우 렌더링 */}
         {windows.map((window) => {
-          // category별로 다른 컴포넌트 렌더링
+          // 카테고리별로 다른 컴포넌트 렌더링
           const renderWindowContent = () => {
             switch (window.category) {
               case "home":

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import type { ComponentType } from "react";
 
 import Shortcut from "@/components/os/Shortcut/Shortcut";
 import Taskbar from "@/components/os/Taskbar/Taskbar";
@@ -16,6 +17,19 @@ const DESKTOP_SHORTCUTS = [
   { category: "friends", config: WINDOW_APP.FRIENDS },
   { category: "settings", config: WINDOW_APP.SETTINGS },
 ] as const;
+
+function createPlannedComponent() {
+  return () => <div>(구현 예정)</div>;
+}
+
+const WINDOW_COMPONENT_MAP: Record<string, ComponentType> = {
+  home: MiniHome,
+  gallery: createPlannedComponent(),
+  memo: createPlannedComponent(),
+  guestbook: createPlannedComponent(),
+  friends: createPlannedComponent(),
+  settings: createPlannedComponent(),
+};
 
 export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);
@@ -74,26 +88,9 @@ export default function OsMain() {
         </div>
         {/* 윈도우 렌더링 */}
         {windows.map((window) => {
-          // 카테고리별로 다른 컴포넌트 렌더링
-          const renderWindowContent = () => {
-            switch (window.category) {
-              case "home":
-                return <MiniHome />;
-              case "gallery":
-                return <div>Gallery (구현 예정)</div>;
-              case "memo":
-                return <div>Memo (구현 예정)</div>;
-              case "guestbook":
-                return <div>Guest Book (구현 예정)</div>;
-              case "friends":
-                return <div>Friends (구현 예정)</div>;
-              case "settings":
-                return <div>Settings (구현 예정)</div>;
-              default:
-                return null;
-            }
-          };
-
+          // 카테고리에 맞는 컴포넌트를 맵에서 찾아 해당 창에 렌더링
+          const WindowContent = WINDOW_COMPONENT_MAP[window.category];
+          if (!WindowContent) return null;
           return (
             <Window
               key={window.category}
@@ -104,7 +101,7 @@ export default function OsMain() {
               title={window.title}
               icon={window.icon}
             >
-              {renderWindowContent()}
+              <WindowContent />
             </Window>
           );
         })}

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -51,27 +51,27 @@ export default function OsMain() {
   };
 
   return (
-    <main ref={ref} className="bg-surface relative flex h-screen flex-col overflow-hidden">
+    <main ref={ref} className="bg-surface flex h-screen flex-col">
       {/* 바탕화면 영역 */}
       <div className="flex-1 p-4">
-        {/* 숏컷 영역 */}
-        <ul className="flex w-16 flex-col gap-4" aria-label="바로가기">
+        {/* 바로가기 그리드 영역 */}
+        <div
+          className="grid h-full w-full auto-cols-[80px] grid-flow-col grid-rows-[repeat(auto-fill,100px)] content-start gap-4"
+          aria-label="바로가기"
+        >
           {DESKTOP_SHORTCUTS.map(({ category, config }) => (
-            <li key={category}>
-              <Shortcut
-                Icon={config.icon}
-                caption={config.caption}
-                isSelected={selectedShortcutCategory === category}
-                isFocused={focusedShortcutCategory === category}
-                onFocus={() => handleShortcutFocus(category)}
-                onBlur={handleShortcutBlur}
-                onDoubleClick={() =>
-                  handleShortcutDoubleClick(category, config.caption, config.icon)
-                }
-              />
-            </li>
+            <Shortcut
+              key={category}
+              Icon={config.icon}
+              caption={config.caption}
+              isSelected={selectedShortcutCategory === category}
+              isFocused={focusedShortcutCategory === category}
+              onFocus={() => handleShortcutFocus(category)}
+              onBlur={handleShortcutBlur}
+              onDoubleClick={() => handleShortcutDoubleClick(category, config.caption, config.icon)}
+            />
           ))}
-        </ul>
+        </div>
         {/* 윈도우 렌더링 */}
         {windows.map((window) => {
           // 카테고리별로 다른 컴포넌트 렌더링

--- a/src/types/window-app.type.ts
+++ b/src/types/window-app.type.ts
@@ -1,34 +1,51 @@
+import { createElement, type ComponentType } from "react";
+
 import Friends from "@/assets/icons/friends.svg?react";
 import Gallery from "@/assets/icons/gallery.svg?react";
 import Guestbook from "@/assets/icons/guestbook.svg?react";
 import Home from "@/assets/icons/home.svg?react";
 import Memo from "@/assets/icons/memo.svg?react";
 import Settings from "@/assets/icons/settings.svg?react";
+import MiniHome from "@/pages/minihome/MiniHome";
+
+const todoComponent = (): ComponentType => () => createElement("div", null, "(구현 예정)");
 
 export const WINDOW_APP = {
   HOME: {
+    category: "home",
     caption: "Home",
     icon: Home,
+    component: MiniHome,
   },
   GALLERY: {
+    category: "gallery",
     caption: "Gallery",
     icon: Gallery,
+    component: todoComponent(),
   },
   MEMO: {
+    category: "memo",
     caption: "Memo",
     icon: Memo,
+    component: todoComponent(),
   },
   GUESTBOOK: {
+    category: "guestbook",
     caption: "Guest Book",
     icon: Guestbook,
+    component: todoComponent(),
   },
   FRIENDS: {
+    category: "friends",
     caption: "Friends",
     icon: Friends,
+    component: todoComponent(),
   },
   SETTINGS: {
+    category: "settings",
     caption: "Settings",
     icon: Settings,
+    component: todoComponent(),
   },
 } as const;
 

--- a/src/types/window-app.type.ts
+++ b/src/types/window-app.type.ts
@@ -1,4 +1,4 @@
-import { createElement, type ComponentType } from "react";
+import { createElement } from "react";
 
 import Friends from "@/assets/icons/friends.svg?react";
 import Gallery from "@/assets/icons/gallery.svg?react";
@@ -8,7 +8,7 @@ import Memo from "@/assets/icons/memo.svg?react";
 import Settings from "@/assets/icons/settings.svg?react";
 import MiniHome from "@/pages/minihome/MiniHome";
 
-const todoComponent = (): ComponentType => () => createElement("div", null, "(구현 예정)");
+const todoComponent = () => createElement("div", null, "(구현 예정)");
 
 export const WINDOW_APP = {
   HOME: {
@@ -21,31 +21,31 @@ export const WINDOW_APP = {
     category: "gallery",
     caption: "Gallery",
     icon: Gallery,
-    component: todoComponent(),
+    component: todoComponent,
   },
   MEMO: {
     category: "memo",
     caption: "Memo",
     icon: Memo,
-    component: todoComponent(),
+    component: todoComponent,
   },
   GUESTBOOK: {
     category: "guestbook",
     caption: "Guest Book",
     icon: Guestbook,
-    component: todoComponent(),
+    component: todoComponent,
   },
   FRIENDS: {
     category: "friends",
     caption: "Friends",
     icon: Friends,
-    component: todoComponent(),
+    component: todoComponent,
   },
   SETTINGS: {
     category: "settings",
     caption: "Settings",
     icon: Settings,
-    component: todoComponent(),
+    component: todoComponent,
   },
 } as const;
 


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
메인 페이지에서 바로가기 버튼을 누르면 윈도우 컴포넌트가 열리도록 구현했습니다.
category/icon/caption/component, 정의를 WINDOW_APP 한 곳에서 관리하게 바꿔 구조를 단순화했습니다.


## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #67 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->
- [x] WINDOW_APP에 category 및 component 정보를 추가해 단일 소스로 관리
- [x] OsMain에서 WINDOW_APP 기반으로 바로가기/윈도우 렌더링 로직 리팩터링
- [x] 바로가기 아이콘을 그리드로 변경하고 그리드를 세로정렬 


## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="2867" height="1537" alt="image" src="https://github.com/user-attachments/assets/a99fb87b-2df0-40fc-90c0-e90c56078162" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->
1. window-app.type.ts에 category 및 component를 추가하여서 기존 OsMain에서 Map으로 관리하던 메타데이터를 분리하였습니다,

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
1. window-app.type.ts에 category / component 추가한 것 괜찮은지

2. 바로가기 그리드 크기 80x100 px로 하였는데 크기 괜찮은지

3. (서진님께 질문) 바로가기의 이름이 길어지면 두 줄로 나오는데, 의도된 사항일까요