### PR TITLE
feat(window): 동일 카테고리 윈도우 단독 실행 및 탭 상세 페이지 기능 구현

### DIFF
--- a/src/components/os/Shortcut/Shortcut.tsx
+++ b/src/components/os/Shortcut/Shortcut.tsx
@@ -1,7 +1,7 @@
 import type { ComponentPropsWithRef } from "react";
 import { twMerge } from "tailwind-merge";
 
-import type { WindowApp } from "@/types/window-app.type.ts";
+import type { WindowApp } from "@/types/window.types";
 
 interface ShortcutProps extends ComponentPropsWithRef<"button"> {
   Icon: WindowApp["icon"];
@@ -35,25 +35,20 @@ export default function Shortcut({
   return (
     <button
       type="button"
-      className={twMerge(
-        "group",
-        "inline-flex min-h-16 min-w-16 flex-col items-center justify-center",
-        "gap-1 px-2 py-2",
-        "text-center"
-      )}
+      className={twMerge("group inline-flex flex-col items-center gap-1")}
       {...props}
     >
       <Icon
         className={twMerge(
           "text-text-default",
-          "size-11 md:size-14 lg:size-16",
+          "size-9 md:size-10",
           isSelected && "bg-secondary/80"
         )}
         aria-hidden="true"
       />
       <span
         className={twMerge(
-          "text-text-default",
+          "text-text-default text-xs select-none md:text-sm",
           isSelected && "bg-secondary/80 focus-dotted",
           isFocused && "focus-dotted"
         )}

--- a/src/components/os/Taskbar/Taskbar.tsx
+++ b/src/components/os/Taskbar/Taskbar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { twMerge } from "tailwind-merge";
 
 import { useWindowStore } from "@/stores/useWindowStore";
+import type { WindowAppId } from "@/types/window.types";
 
 import TaskbarStart from "./TaskbarStart";
 import TaskbarSystemTray from "./TaskbarSystemTray";
@@ -57,9 +58,9 @@ export default function Taskbar({ className, config = "default", ...rest }: Task
   const showStart = config === "default" || config === "noSystemTray";
   const showSystemTray = config === "default" || config === "noStartButton";
 
-  const handleTabClick = (id: string) => {
+  const handleTabClick = (id: WindowAppId) => {
     // Taskbar 탭 클릭 시 해당 window로 focus
-    setActiveWindow(id as any); // WindowAppId로 타입 캐스팅
+    setActiveWindow(id);
   };
 
   return (

--- a/src/components/os/Taskbar/Taskbar.tsx
+++ b/src/components/os/Taskbar/Taskbar.tsx
@@ -49,30 +49,30 @@ type TaskbarProps = React.ComponentPropsWithoutRef<"nav"> & {
 export default function Taskbar({ className, config = "default", ...rest }: TaskbarProps) {
   // Taskbar 탭으로 노출할 전체 창 목록
   const windows = useWindowStore((state) => state.windows);
-  // 현재 포커스된 창의 카테고리
-  const focusedWindowCategory = useWindowStore((state) => state.focusedWindowCategory);
+  // 현재 포커스된 창의 ID
+  const activeWindowId = useWindowStore((state) => state.activeWindowId);
   // 특정 창으로 포커스를 이동시키는 액션
-  const setFocusWindow = useWindowStore((state) => state.setFocusWindow);
+  const setActiveWindow = useWindowStore((state) => state.setActiveWindow);
 
   const showStart = config === "default" || config === "noSystemTray";
   const showSystemTray = config === "default" || config === "noStartButton";
 
-  const handleTabClick = (category: string) => {
+  const handleTabClick = (id: string) => {
     // Taskbar 탭 클릭 시 해당 window로 focus
-    setFocusWindow(category);
+    setActiveWindow(id as any); // WindowAppId로 타입 캐스팅
   };
 
   return (
     <nav className={twMerge(taskbar, className)} {...rest}>
       {showStart && <TaskbarStart />}
       <ul className="flex flex-1 items-center gap-1 overflow-hidden">
-        {windows.map((window) => (
-          <li key={window.category} className="@container flex max-w-43 min-w-0 flex-1">
+        {Object.values(windows).map((app) => (
+          <li key={app.id} className="@container flex max-w-43 min-w-0 flex-1">
             <TaskbarTab
-              icon={window.icon}
-              title={window.title}
-              isFocused={window.category === focusedWindowCategory}
-              onClick={() => handleTabClick(window.category)}
+              icon={app.icon}
+              title={app.caption}
+              isFocused={app.id === activeWindowId}
+              onClick={() => handleTabClick(app.id)}
             />
           </li>
         ))}

--- a/src/components/os/Taskbar/Taskbar.tsx
+++ b/src/components/os/Taskbar/Taskbar.tsx
@@ -67,13 +67,13 @@ export default function Taskbar({ className, config = "default", ...rest }: Task
     <nav className={twMerge(taskbar, className)} {...rest}>
       {showStart && <TaskbarStart />}
       <ul className="flex flex-1 items-center gap-1 overflow-hidden">
-        {Object.values(windows).map((app) => (
-          <li key={app.id} className="@container flex max-w-43 min-w-0 flex-1">
+        {Object.values(windows).map((window) => (
+          <li key={window.id} className="@container flex max-w-43 min-w-0 flex-1">
             <TaskbarTab
-              icon={app.icon}
-              title={app.caption}
-              isFocused={app.id === activeWindowId}
-              onClick={() => handleTabClick(app.id)}
+              icon={window.icon}
+              title={window.caption}
+              isFocused={window.id === activeWindowId}
+              onClick={() => handleTabClick(window.id)}
             />
           </li>
         ))}

--- a/src/components/os/Taskbar/TaskbarTab.tsx
+++ b/src/components/os/Taskbar/TaskbarTab.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, SVGProps } from "react";
+import type { FunctionComponent, SVGProps } from "react";
 import { twMerge } from "tailwind-merge";
 
 import Button from "@/components/common/Button/Button";
@@ -6,7 +6,7 @@ import Button from "@/components/common/Button/Button";
 import { taskbarTab } from "./variants";
 
 interface TaskbarTabProps {
-  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  icon: FunctionComponent<SVGProps<SVGSVGElement>>;
   title: string;
   isFocused?: boolean;
   className?: string;

--- a/src/components/os/Taskbar/TaskbarTab.tsx
+++ b/src/components/os/Taskbar/TaskbarTab.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentType, SVGProps } from "react";
 import { twMerge } from "tailwind-merge";
 
 import Button from "@/components/common/Button/Button";
@@ -6,7 +6,7 @@ import Button from "@/components/common/Button/Button";
 import { taskbarTab } from "./variants";
 
 interface TaskbarTabProps {
-  icon: ReactNode;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   title: string;
   isFocused?: boolean;
   className?: string;
@@ -23,7 +23,7 @@ interface TaskbarTabProps {
  * Button 컴포넌트를 기반으로 구현되었습니다.
  *
  * @component
- * @param {ReactNode} icon - 아이콘을 나타내는 React 노드
+ * @param {ComponentType<SVGProps<SVGSVGElement>>} icon - 아이콘 컴포넌트
  * @param {string} title - 탭에 표시할 윈도우 제목
  * @param {boolean} [isFocused=false] - focus 상태 (true면 pressed, false면 neutral)
  * @param {string} [className] - 추가 Tailwind 클래스
@@ -32,11 +32,11 @@ interface TaskbarTabProps {
  *
  * @example
  * ```tsx
- * <TaskbarTab icon={<Folder size={14} />} title="My Computer" isFocused />
+ * <TaskbarTab icon={Folder} title="My Computer" isFocused />
  * ```
  */
 export default function TaskbarTab({
-  icon,
+  icon: Icon,
   title,
   isFocused = false,
   className,
@@ -51,8 +51,10 @@ export default function TaskbarTab({
       className={twMerge(taskbarTab, className)}
       onClick={onClick}
     >
-      <span className="flex overflow-hidden">
-        <span className="shrink-0">{icon}</span>
+      <span className="flex gap-1.5 overflow-hidden">
+        <span className="shrink-0">
+          <Icon className="h-3.5 w-3.5" />
+        </span>
         {title && (
           <span className="min-w-0 flex-1 truncate @max-[44px]:hidden" title={title}>
             {title}

--- a/src/components/window/TitleBar/TitleBar.tsx
+++ b/src/components/window/TitleBar/TitleBar.tsx
@@ -1,6 +1,5 @@
-// TitleBar.tsx
 import { AppWindow, Minus, X } from "lucide-react";
-import React from "react";
+import React, { type ComponentType, type SVGProps } from "react";
 import { twMerge } from "tailwind-merge";
 
 import Button from "@/components/common/Button/Button";
@@ -22,16 +21,10 @@ const sizeConfig = {
 } as const;
 
 export interface TitleBarProps extends React.ComponentPropsWithoutRef<"div">, TitleBarVariantProps {
-  icon?: React.ReactNode;
-  text?: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>; // FunctionComponent → ComponentType
+  title?: string; // text → title (prop 이름 통일)
   buttons?: "all" | "closeOnly" | null;
   onClose?: () => void;
-}
-
-function isElementWithClassName(
-  node: React.ReactNode
-): node is React.ReactElement<{ className?: string }> {
-  return React.isValidElement(node);
 }
 
 /**
@@ -49,12 +42,12 @@ function isElementWithClassName(
  * @param {"small" | "medium"} [size="small"]
  *   - TitleBar 전체 높이 및 내부 요소(Button, Icon)의 크기를 조절합니다.
  *
- * @param {React.ReactNode} [icon]
- *   - TitleBar 좌측에 표시되는 아이콘 요소입니다.
- *     ReactElement로 전달되며, TitleBar 크기에 맞춰 자동으로 리사이징됩니다.
+ * @param {ComponentType<SVGProps<SVGSVGElement>>} [icon]
+ *   - TitleBar 좌측에 표시되는 아이콘 컴포넌트입니다.
+ *     TitleBar 크기에 맞춰 자동으로 리사이징됩니다.
  *
- * @param {React.ReactNode} [text]
- *   - 제목 문자열 또는 JSX로 전달할 수 있는 TitleBar의 중앙 텍스트입니다.
+ * @param {string} [title]
+ *   - 제목 문자열로 TitleBar의 중앙에 표시됩니다.
  *
  * @param {"all" | "closeOnly" | null} [buttons=null]
  *   - 우측 컨트롤 버튼 표시 옵션입니다.
@@ -75,8 +68,8 @@ function isElementWithClassName(
  * <TitleBar
  *   size="small"
  *   state="active"
- *   icon={<Folder />}
- *   text="My Computer"
+ *   icon={Folder}
+ *   title="My Computer"
  *   buttons="all"
  * />
  * ```
@@ -85,8 +78,8 @@ function isElementWithClassName(
  * ```tsx
  * <TitleBar
  *   size="medium"
- *   icon={<Image />}
- *   text="Photos Viewer"
+ *   icon={Image}
+ *   title="Photos Viewer"
  *   buttons="closeOnly"
  * />
  * ```
@@ -95,7 +88,7 @@ function isElementWithClassName(
 export default function TitleBar({
   state = "active",
   size = "small",
-  icon,
+  icon: Icon,
   title,
   buttons = null,
   onClose,
@@ -103,12 +96,6 @@ export default function TitleBar({
   ...rest
 }: TitleBarProps) {
   const { iconClassName, buttonSizeClass, iconSizeClass } = sizeConfig[size ?? "small"];
-
-  const sizedIcon = isElementWithClassName(icon)
-    ? React.cloneElement(icon, {
-        className: twMerge(icon.props.className, iconSizeClass, "text-accent-contrast"),
-      })
-    : null;
 
   return (
     <header
@@ -122,7 +109,11 @@ export default function TitleBar({
       {...rest}
     >
       <div className="flex min-w-0 flex-1 items-center gap-1.5 px-1.5">
-        {sizedIcon && <div className="shrink-0">{sizedIcon}</div>}
+        {Icon && (
+          <div className="shrink-0">
+            <Icon className={twMerge(iconSizeClass, "text-accent-contrast")} />
+          </div>
+        )}
         <div className="text-accent-contrast truncate whitespace-nowrap">{title}</div>
       </div>
 

--- a/src/components/window/TitleBar/TitleBar.tsx
+++ b/src/components/window/TitleBar/TitleBar.tsx
@@ -1,5 +1,5 @@
 import { AppWindow, Minus, X } from "lucide-react";
-import React, { type ComponentType, type SVGProps } from "react";
+import React, { type FunctionComponent, type SVGProps } from "react";
 import { twMerge } from "tailwind-merge";
 
 import Button from "@/components/common/Button/Button";
@@ -21,7 +21,7 @@ const sizeConfig = {
 } as const;
 
 export interface TitleBarProps extends React.ComponentPropsWithoutRef<"div">, TitleBarVariantProps {
-  icon?: ComponentType<SVGProps<SVGSVGElement>>; // FunctionComponent → ComponentType
+  icon?: FunctionComponent<SVGProps<SVGSVGElement>>; // FunctionComponent → ComponentType
   title?: string; // text → title (prop 이름 통일)
   buttons?: "all" | "closeOnly" | null;
   onClose?: () => void;

--- a/src/config/window.tsx
+++ b/src/config/window.tsx
@@ -1,5 +1,3 @@
-import { createElement } from "react";
-
 import Friends from "@/assets/icons/friends.svg?react";
 import Gallery from "@/assets/icons/gallery.svg?react";
 import Guestbook from "@/assets/icons/guestbook.svg?react";
@@ -7,45 +5,43 @@ import Home from "@/assets/icons/home.svg?react";
 import Memo from "@/assets/icons/memo.svg?react";
 import Settings from "@/assets/icons/settings.svg?react";
 import MiniHome from "@/pages/minihome/MiniHome";
+import { MINIHOME_TABS } from "@/types/minihome.types";
+import type { WindowApp, WindowAppId } from "@/types/window.types";
 
-const todoComponent = () => createElement("div", null, "(구현 예정)");
-
-export const WINDOW_APPS = {
-  HOME: {
-    category: "home",
+export const WINDOW_APPS: Record<WindowAppId, WindowApp> = {
+  home: {
+    id: "home",
     caption: "Home",
     icon: Home,
     component: MiniHome,
   },
-  GALLERY: {
-    category: "gallery",
+  gallery: {
+    id: "gallery",
     caption: "Gallery",
     icon: Gallery,
-    component: todoComponent,
+    component: () => <MiniHome tab={MINIHOME_TABS.GALLERY} />,
   },
-  MEMO: {
-    category: "memo",
+  memo: {
+    id: "memo",
     caption: "Memo",
     icon: Memo,
-    component: todoComponent,
+    component: () => <MiniHome tab={MINIHOME_TABS.MEMO} />,
   },
-  GUESTBOOK: {
-    category: "guestbook",
+  guestbook: {
+    id: "guestbook",
     caption: "Guest Book",
     icon: Guestbook,
-    component: todoComponent,
+    component: () => <MiniHome tab={MINIHOME_TABS.GUESTBOOK} />,
   },
-  FRIENDS: {
-    category: "friends",
+  friends: {
+    id: "friends",
     caption: "Friends",
     icon: Friends,
-    component: todoComponent,
   },
-  SETTINGS: {
-    category: "settings",
+  settings: {
+    id: "settings",
     caption: "Settings",
     icon: Settings,
-    component: todoComponent,
   },
 } as const;
 

--- a/src/config/window.tsx
+++ b/src/config/window.tsx
@@ -19,19 +19,19 @@ export const WINDOW_APPS: Record<WindowAppId, WindowApp> = {
     id: "gallery",
     caption: "Gallery",
     icon: Gallery,
-    component: () => <MiniHome tab={MINIHOME_TABS.GALLERY} />,
+    component: () => <MiniHome tab={MINIHOME_TABS.gallery} />,
   },
   memo: {
     id: "memo",
     caption: "Memo",
     icon: Memo,
-    component: () => <MiniHome tab={MINIHOME_TABS.MEMO} />,
+    component: () => <MiniHome tab={MINIHOME_TABS.memo} />,
   },
   guestbook: {
     id: "guestbook",
     caption: "Guest Book",
     icon: Guestbook,
-    component: () => <MiniHome tab={MINIHOME_TABS.GUESTBOOK} />,
+    component: () => <MiniHome tab={MINIHOME_TABS.guestbook} />,
   },
   friends: {
     id: "friends",

--- a/src/config/window.tsx
+++ b/src/config/window.tsx
@@ -11,35 +11,41 @@ import type { WindowApp, WindowAppId } from "@/types/window.types";
 export const WINDOW_APPS: Record<WindowAppId, WindowApp> = {
   home: {
     id: "home",
+    category: "minihome",
     caption: "Home",
     icon: Home,
     component: MiniHome,
   },
   gallery: {
     id: "gallery",
+    category: "minihome",
     caption: "Gallery",
     icon: Gallery,
     component: () => <MiniHome tab={MINIHOME_TABS.gallery} />,
   },
   memo: {
     id: "memo",
+    category: "minihome",
     caption: "Memo",
     icon: Memo,
     component: () => <MiniHome tab={MINIHOME_TABS.memo} />,
   },
   guestbook: {
     id: "guestbook",
+    category: "minihome",
     caption: "Guest Book",
     icon: Guestbook,
     component: () => <MiniHome tab={MINIHOME_TABS.guestbook} />,
   },
   friends: {
     id: "friends",
+    category: "friends",
     caption: "Friends",
     icon: Friends,
   },
   settings: {
     id: "settings",
+    category: "settings",
     caption: "Settings",
     icon: Settings,
   },

--- a/src/pages/MockLoginPage.tsx
+++ b/src/pages/MockLoginPage.tsx
@@ -1,3 +1,0 @@
-export default function MockLoginPage() {
-  return <h1>MockLoginPage Component</h1>;
-}

--- a/src/pages/MockMainPage.tsx
+++ b/src/pages/MockMainPage.tsx
@@ -1,3 +1,0 @@
-export default function MockMainPage() {
-  return <h1>MockMainPage Component</h1>;
-}

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -34,17 +34,16 @@ export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeT
           </Tabs.Trigger>
         ))}
       </Tabs.List>
-      {/* TODO: 컴포넌트 주입해주시면 됩니다. */}
       <Tabs.Content value={MINIHOME_TABS.home}>
         <Activity>홈</Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.gallery}>
         <Activity>
-          사진첩
+          갤러리
           {/* {galleryDetail.selectedId ? (
             <GalleryDetail photoId={galleryDetail.selectedId} onBack={galleryDetail.exitDetail} />
           ) : (
-            <Gallery onSelectPhoto={galleryDetail.enterDetail} />
+            <GalleryList onSelectPhoto={galleryDetail.enterDetail} />
           )} */}
         </Activity>
       </Tabs.Content>
@@ -54,12 +53,12 @@ export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeT
           {/* {memoDetail.selectedId ? (
             <MemoDetail memoId={memoDetail.selectedId} onBack={memoDetail.exitDetail} />
           ) : (
-            <Memo onSelectMemo={memoDetail.enterDetail} />
+            <MemoList onSelectMemo={memoDetail.enterDetail} />
           )} */}
         </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.guestbook}>
-        <Activity>방명록{/* <GuestBook /> */}</Activity>
+        <Activity>방명록</Activity>
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,11 +1,28 @@
 import * as Tabs from "@radix-ui/react-tabs";
-import { Activity, useState } from "react";
+import { Activity, useEffect, useState } from "react";
 
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
 
-export default function MiniHome({ tab = "Home" }: { tab?: MiniHomeTabs }) {
+function useDetailState<TabId>() {
+  const [selectedId, setSelectedId] = useState<TabId | null>(null);
+
+  const enterDetail = (id: TabId) => setSelectedId(id);
+  const exitDetail = () => setSelectedId(null);
+
+  return { selectedId, enterDetail, exitDetail };
+}
+
+export default function MiniHome({ tab = MINIHOME_TABS.HOME }: { tab?: MiniHomeTabs }) {
   const [activeTab, setActiveTab] = useState<MiniHomeTabs>(tab);
+
+  const galleryDetail = useDetailState<string>();
+  const memoDetail = useDetailState<string>();
+
+  useEffect(() => {
+    galleryDetail.exitDetail();
+    memoDetail.exitDetail();
+  }, [activeTab, galleryDetail, memoDetail]);
 
   return (
     <Tabs.Root value={activeTab} onValueChange={(value) => setActiveTab(value as MiniHomeTabs)}>
@@ -21,10 +38,24 @@ export default function MiniHome({ tab = "Home" }: { tab?: MiniHomeTabs }) {
         <Activity>홈</Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.GALLERY}>
-        <Activity>사진첩</Activity>
+        <Activity>
+          사진첩
+          {/* {galleryDetail.selectedId ? (
+            <GalleryDetail photoId={galleryDetail.selectedId} onBack={galleryDetail.exitDetail} />
+          ) : (
+            <Gallery onSelectPhoto={galleryDetail.enterDetail} />
+          )} */}
+        </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.MEMO}>
-        <Activity>메모장</Activity>
+        <Activity>
+          메모
+          {/* {memoDetail.selectedId ? (
+            <MemoDetail memoId={memoDetail.selectedId} onBack={memoDetail.exitDetail} />
+          ) : (
+            <Memo onSelectMemo={memoDetail.enterDetail} />
+          )} */}
+        </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.GUESTBOOK}>
         <Activity>방명록</Activity>

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,6 +1,7 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { Activity, useEffect, useState } from "react";
 
+import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
 
@@ -58,7 +59,9 @@ export default function MiniHome({ tab = MINIHOME_TABS.HOME }: { tab?: MiniHomeT
         </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.GUESTBOOK}>
-        <Activity>방명록</Activity>
+        <Activity>
+          <GuestBook />
+        </Activity>
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -14,7 +14,7 @@ function useDetailState<TabId>() {
   return { selectedId, enterDetail, exitDetail };
 }
 
-export default function MiniHome({ tab = MINIHOME_TABS.HOME }: { tab?: MiniHomeTabs }) {
+export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeTabs }) {
   const [activeTab, setActiveTab] = useState<MiniHomeTabs>(tab);
 
   const galleryDetail = useDetailState<string>();
@@ -35,10 +35,10 @@ export default function MiniHome({ tab = MINIHOME_TABS.HOME }: { tab?: MiniHomeT
         ))}
       </Tabs.List>
       {/* TODO: 컴포넌트 주입해주시면 됩니다. */}
-      <Tabs.Content value={MINIHOME_TABS.HOME}>
+      <Tabs.Content value={MINIHOME_TABS.home}>
         <Activity>홈</Activity>
       </Tabs.Content>
-      <Tabs.Content value={MINIHOME_TABS.GALLERY}>
+      <Tabs.Content value={MINIHOME_TABS.gallery}>
         <Activity>
           사진첩
           {/* {galleryDetail.selectedId ? (
@@ -48,7 +48,7 @@ export default function MiniHome({ tab = MINIHOME_TABS.HOME }: { tab?: MiniHomeT
           )} */}
         </Activity>
       </Tabs.Content>
-      <Tabs.Content value={MINIHOME_TABS.MEMO}>
+      <Tabs.Content value={MINIHOME_TABS.memo}>
         <Activity>
           메모
           {/* {memoDetail.selectedId ? (
@@ -58,7 +58,7 @@ export default function MiniHome({ tab = MINIHOME_TABS.HOME }: { tab?: MiniHomeT
           )} */}
         </Activity>
       </Tabs.Content>
-      <Tabs.Content value={MINIHOME_TABS.GUESTBOOK}>
+      <Tabs.Content value={MINIHOME_TABS.guestbook}>
         <Activity>
           <GuestBook />
         </Activity>

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,7 +1,6 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { Activity, useEffect, useState } from "react";
 
-import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
 
@@ -23,7 +22,8 @@ export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeT
   useEffect(() => {
     galleryDetail.exitDetail();
     memoDetail.exitDetail();
-  }, [activeTab, galleryDetail, memoDetail]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
 
   return (
     <Tabs.Root value={activeTab} onValueChange={(value) => setActiveTab(value as MiniHomeTabs)}>
@@ -59,9 +59,7 @@ export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeT
         </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.guestbook}>
-        <Activity>
-          <GuestBook />
-        </Activity>
+        <Activity>방명록{/* <GuestBook /> */}</Activity>
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -1,90 +1,81 @@
 import { useRef, useState } from "react";
-import type { ComponentType } from "react";
 
 import Shortcut from "@/components/os/Shortcut/Shortcut";
 import Taskbar from "@/components/os/Taskbar/Taskbar";
 import Window from "@/components/window/Window/Window";
+import { WINDOW_APPS } from "@/config/window";
 import { useWindowStore } from "@/stores/useWindowStore";
-import { WINDOW_APPS, type WindowApps } from "@/types/window-app.type";
-
-const WINDOW_CONFIGS: WindowApps[] = Object.values(WINDOW_APPS);
+import type { WindowAppId } from "@/types/window.types";
 
 export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);
-  const { windows, runWindow, closeWindow } = useWindowStore();
-  const [selectedShortcutCategory, setSelectedShortcutCategory] = useState<string | null>(null);
-  const [focusedShortcutCategory, setFocusedShortcutCategory] = useState<string | null>(null);
+  const [selectedShortcutId, setSelectedShortcutId] = useState<string | null>(null);
+  const [focusedShortcutId, setFocusedShortcutId] = useState<string | null>(null);
+  const { windows, openWindow, closeWindow } = useWindowStore();
 
-  const handleShortcutFocus = (category: string) => {
-    // 포커스가 들어올 때 -> isSelected와 isFocused 모두 true
-    setSelectedShortcutCategory(category);
-    setFocusedShortcutCategory(category);
+  const handleShortcutFocus = (id: string) => {
+    setSelectedShortcutId(id);
+    setFocusedShortcutId(id);
   };
 
   const handleShortcutBlur = () => {
-    // 포커스가 다른 곳으로 이동할 때 selected 해제
-    setSelectedShortcutCategory(null);
+    setSelectedShortcutId(null);
   };
 
-  const handleShortcutDoubleClick = (
-    category: string,
-    title: string,
-    IconComponent: ComponentType
-  ) => {
-    runWindow({
-      category,
-      title,
-      icon: <IconComponent />,
-    });
-
-    // 더블클릭 시 상태 해제
-    setSelectedShortcutCategory(null);
-    setFocusedShortcutCategory(null);
+  const handleShortcutDoubleClick = (id: WindowAppId) => {
+    openWindow(id);
+    setSelectedShortcutId(null);
+    setFocusedShortcutId(null);
   };
 
   return (
-    <main ref={ref} className="bg-surface flex h-screen flex-col">
-      {/* 바탕화면 영역 */}
+    <main ref={ref} className="bg-base-2 flex h-screen flex-col">
       <div className="flex-1 p-4">
-        {/* 바로가기 그리드 영역 */}
         <div
-          className="grid h-full w-full auto-cols-[80px] grid-flow-col grid-rows-[repeat(auto-fill,100px)] content-start gap-4"
+          className="grid h-full w-full auto-cols-max grid-flow-row auto-rows-max gap-6 md:gap-8"
           aria-label="바로가기"
         >
-          {WINDOW_CONFIGS.map(({ category, icon, caption }) => (
+          {Object.values(WINDOW_APPS).map(({ id, icon, caption }) => (
             <Shortcut
-              key={category}
+              key={id}
               Icon={icon}
               caption={caption}
-              isSelected={selectedShortcutCategory === category}
-              isFocused={focusedShortcutCategory === category}
-              onFocus={() => handleShortcutFocus(category)}
+              isSelected={selectedShortcutId === id}
+              isFocused={focusedShortcutId === id}
+              onFocus={() => handleShortcutFocus(id)}
               onBlur={handleShortcutBlur}
-              onDoubleClick={() => handleShortcutDoubleClick(category, caption, icon)}
+              onDoubleClick={() => handleShortcutDoubleClick(id)}
             />
           ))}
         </div>
-        {/* 윈도우 렌더링 */}
-        {windows.map((window) => {
-          const windowConfig = WINDOW_CONFIGS.find((config) => config.category === window.category);
-          const WindowContent = windowConfig?.component;
-          if (!WindowContent) return null;
-          return (
-            <Window
-              key={window.category}
-              ref={ref}
-              open
-              buttons="all"
-              onClose={() => closeWindow(window.category)}
-              title={window.title}
-              icon={window.icon}
-            >
-              <WindowContent />
-            </Window>
-          );
-        })}
+
+        {Object.values(windows)
+          .filter((windowState, index, arr) => {
+            const minihomeIds = ["home", "gallery", "memo", "guestbook"];
+            if (minihomeIds.includes(windowState.id)) {
+              return arr.findIndex((w) => minihomeIds.includes(w.id)) === index;
+            }
+            return true;
+          })
+          .map((windowState) => {
+            const Component = windowState.component;
+            if (!Component) return null;
+
+            return (
+              <Window
+                key={windowState.id}
+                ref={ref}
+                open
+                buttons="all"
+                onClose={() => closeWindow(windowState.id)}
+                title={windowState.caption}
+                icon={windowState.icon}
+              >
+                <Component />
+              </Window>
+            );
+          })}
       </div>
-      {/* 태스크바 영역 */}
       <Taskbar />
     </main>
   );

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -5,9 +5,9 @@ import Shortcut from "@/components/os/Shortcut/Shortcut";
 import Taskbar from "@/components/os/Taskbar/Taskbar";
 import Window from "@/components/window/Window/Window";
 import { useWindowStore } from "@/stores/useWindowStore";
-import { WINDOW_APPS, type WindowApp } from "@/types/window-app.type";
+import { WINDOW_APPS, type WindowApps } from "@/types/window-app.type";
 
-const WINDOW_CONFIGS: WindowApp[] = Object.values(WINDOW_APPS);
+const WINDOW_CONFIGS: WindowApps[] = Object.values(WINDOW_APPS);
 
 export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -49,32 +49,24 @@ export default function OsMain() {
           ))}
         </div>
 
-        {Object.values(windows)
-          .filter((windowState, index, arr) => {
-            const minihomeIds = ["home", "gallery", "memo", "guestbook"];
-            if (minihomeIds.includes(windowState.id)) {
-              return arr.findIndex((w) => minihomeIds.includes(w.id)) === index;
-            }
-            return true;
-          })
-          .map((windowState) => {
-            const Component = windowState.component;
-            if (!Component) return null;
+        {Object.values(windows).map((windowState) => {
+          const Component = windowState.component;
+          if (!Component) return null;
 
-            return (
-              <Window
-                key={windowState.id}
-                ref={ref}
-                open
-                buttons="all"
-                onClose={() => closeWindow(windowState.id)}
-                title={windowState.caption}
-                icon={windowState.icon}
-              >
-                <Component />
-              </Window>
-            );
-          })}
+          return (
+            <Window
+              key={windowState.id}
+              ref={ref}
+              open
+              buttons="all"
+              onClose={() => closeWindow(windowState.id)}
+              title={windowState.caption}
+              icon={windowState.icon}
+            >
+              <Component />
+            </Window>
+          );
+        })}
       </div>
       <Taskbar />
     </main>

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -16,6 +16,12 @@ interface WindowStore {
 
 const isMiniHomeTab = (id: WindowAppId) => id in MINIHOME_TABS;
 
+const clearMiniHomeTabs = (windows: Partial<Record<WindowAppId, WindowApp>>) => {
+  Object.keys(MINIHOME_TABS).forEach((key) => {
+    delete windows[key as WindowAppId];
+  });
+};
+
 export const useWindowStore = create<WindowStore>()(
   devtools(
     immer((set) => ({
@@ -28,9 +34,7 @@ export const useWindowStore = create<WindowStore>()(
           if (!appConfig) return;
 
           if (isMiniHomeTab(id)) {
-            Object.keys(MINIHOME_TABS).forEach((key) => {
-              delete state.windows[key as WindowAppId];
-            });
+            clearMiniHomeTabs(state.windows);
           }
 
           state.windows[id] = appConfig;
@@ -39,15 +43,7 @@ export const useWindowStore = create<WindowStore>()(
 
       closeWindow: (id) =>
         set((state) => {
-          if (isMiniHomeTab(id)) {
-            Object.keys(state.windows).forEach((key) => {
-              if (isMiniHomeTab(key as WindowAppId)) {
-                delete state.windows[key as WindowAppId];
-              }
-            });
-          } else {
-            delete state.windows[id];
-          }
+          delete state.windows[id];
 
           if (state.activeWindowId === id) {
             state.activeWindowId = null;

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -1,82 +1,50 @@
-import type { ReactNode } from "react";
 import { create } from "zustand";
+import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
-/**
- * 우선 Taskbar에서 필요한 최소한의 Window 정보만 만들었습니다
- */
-
-interface WindowInfo {
-  /** Window의 카테고리 */
-  category: string;
-  /** Taskbar에 표시되는 제목 */
-  title: string;
-  /** 제목 옆에 선택적으로 표시되는 아이콘 (ReactNode) */
-  icon?: ReactNode;
-}
+import { WINDOW_APPS } from "@/config/window";
+import type { WindowApp, WindowAppId } from "@/types/window.types";
 
 interface WindowStore {
-  windows: WindowInfo[];
-  focusedWindowCategory: string | null;
-
-  /**
-   * Store에 새로운 Window를 추가하고 focus 상태를 설정합니다
-   * @param window - 추가할 Window 정보
-   */
-  runWindow: (window: WindowInfo) => void;
-
-  /**
-   * Store에서 Window를 제거합니다. 제거된 Window가 focus였을 경우,
-   * focusedWindowCategory를 null으로 설정합니다.
-   * 다른 Window로 자동 focus를 옮기지 않습니다 (사용자가 직접 선택하도록).
-   * @param category - 제거할 Window의 카테고리
-   */
-  closeWindow: (category: string) => void;
-
-  /**
-   * focus 중인 Window를 설정합니다. Window 카테고리가 존재하지 않으면 동작하지 않습니다
-   * @param category - Focus할 Window의 카테고리
-   */
-  setFocusWindow: (category: string) => void;
+  windows: Partial<Record<WindowAppId, WindowApp>>;
+  activeWindowId: WindowAppId | null;
+  openWindow: (id: WindowAppId) => void;
+  closeWindow: (id: WindowAppId) => void;
+  setActiveWindow: (id: WindowAppId) => void;
 }
 
 export const useWindowStore = create<WindowStore>()(
-  immer((set) => ({
-    windows: [],
-    focusedWindowCategory: null,
+  devtools(
+    immer((set) => ({
+      windows: {},
+      activeWindowId: null,
 
-    // Window 등록 (Taskbar 맨 뒤에 탭 추가)
-    runWindow: (window) =>
-      set((state) => {
-        const exists = state.windows.some((w) => w.category === window.category);
-        if (!exists) {
-          state.windows.push(window);
-          state.focusedWindowCategory = window.category; // 새로 생성된 window를 자동으로 focus
-        }
-      }),
+      openWindow: (id) =>
+        set((state) => {
+          const appConfig = WINDOW_APPS[id];
+          if (!appConfig) return;
 
-    // Window 제거 (Taskbar에서 탭 제거)
-    closeWindow: (category) =>
-      set((state) => {
-        const index = state.windows.findIndex((w) => w.category === category);
-        if (index !== -1) {
-          state.windows.splice(index, 1);
-          // 제거된 window가 focused였으면 focusedWindowCategory를 null으로 설정
-          // 다른 window로 자동 focus를 옮기지 않음 (사용자가 직접 선택하도록)
-          if (state.focusedWindowCategory === category) {
-            state.focusedWindowCategory = null;
+          if (!state.windows[id]) {
+            state.windows[id] = appConfig;
           }
-        }
-      }),
+          state.activeWindowId = id;
+        }),
 
-    // Window Focus (Taskbar 탭도 focus)
-    setFocusWindow: (category) =>
-      set((state) => {
-        // window가 존재하는지 확인
-        const window = state.windows.find((w) => w.category === category);
-        if (window) {
-          state.focusedWindowCategory = category;
-        }
-      }),
-  }))
+      closeWindow: (id) =>
+        set((state) => {
+          delete state.windows[id];
+          if (state.activeWindowId === id) {
+            state.activeWindowId = null;
+          }
+        }),
+
+      setActiveWindow: (id) =>
+        set((state) => {
+          if (state.windows[id]) {
+            state.activeWindowId = id;
+          }
+        }),
+    })),
+    { name: "WindowStore" }
+  )
 );

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -3,6 +3,7 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { WINDOW_APPS } from "@/config/window";
+import { MINIHOME_TABS } from "@/types/minihome.types";
 import type { WindowApp, WindowAppId } from "@/types/window.types";
 
 interface WindowStore {
@@ -12,6 +13,8 @@ interface WindowStore {
   closeWindow: (id: WindowAppId) => void;
   setActiveWindow: (id: WindowAppId) => void;
 }
+
+const isMiniHomeTab = (id: WindowAppId) => id in MINIHOME_TABS;
 
 export const useWindowStore = create<WindowStore>()(
   devtools(
@@ -24,15 +27,28 @@ export const useWindowStore = create<WindowStore>()(
           const appConfig = WINDOW_APPS[id];
           if (!appConfig) return;
 
-          if (!state.windows[id]) {
-            state.windows[id] = appConfig;
+          if (isMiniHomeTab(id)) {
+            Object.keys(MINIHOME_TABS).forEach((key) => {
+              delete state.windows[key as WindowAppId];
+            });
           }
+
+          state.windows[id] = appConfig;
           state.activeWindowId = id;
         }),
 
       closeWindow: (id) =>
         set((state) => {
-          delete state.windows[id];
+          if (isMiniHomeTab(id)) {
+            Object.keys(state.windows).forEach((key) => {
+              if (isMiniHomeTab(key as WindowAppId)) {
+                delete state.windows[key as WindowAppId];
+              }
+            });
+          } else {
+            delete state.windows[id];
+          }
+
           if (state.activeWindowId === id) {
             state.activeWindowId = null;
           }

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -3,8 +3,7 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { WINDOW_APPS } from "@/config/window";
-import { MINIHOME_TABS } from "@/types/minihome.types";
-import type { WindowApp, WindowAppId } from "@/types/window.types";
+import type { WindowApp, WindowAppId, WindowCategory } from "@/types/window.types";
 
 interface WindowStore {
   windows: Partial<Record<WindowAppId, WindowApp>>;
@@ -12,14 +11,18 @@ interface WindowStore {
   openWindow: (id: WindowAppId) => void;
   closeWindow: (id: WindowAppId) => void;
   setActiveWindow: (id: WindowAppId) => void;
+  updateWindowTitle: (id: WindowAppId, title: string) => void;
 }
 
-const isMiniHomeTab = (id: WindowAppId) => id in MINIHOME_TABS;
+const clearWindowsByCategory = (
+  windows: Partial<Record<WindowAppId, WindowApp>>,
+  category: WindowCategory
+) => {
+  const idsToDelete = Object.values(windows)
+    .filter((window) => window?.category === category)
+    .map((window) => window.id);
 
-const clearMiniHomeTabs = (windows: Partial<Record<WindowAppId, WindowApp>>) => {
-  Object.keys(MINIHOME_TABS).forEach((key) => {
-    delete windows[key as WindowAppId];
-  });
+  idsToDelete.forEach((id) => delete windows[id]);
 };
 
 export const useWindowStore = create<WindowStore>()(
@@ -33,11 +36,14 @@ export const useWindowStore = create<WindowStore>()(
           const appConfig = WINDOW_APPS[id];
           if (!appConfig) return;
 
-          if (isMiniHomeTab(id)) {
-            clearMiniHomeTabs(state.windows);
+          if (state.windows[id]) {
+            state.activeWindowId = id;
+            return;
           }
 
-          state.windows[id] = appConfig;
+          clearWindowsByCategory(state.windows, appConfig.category);
+
+          state.windows[id] = { ...appConfig };
           state.activeWindowId = id;
         }),
 
@@ -54,6 +60,13 @@ export const useWindowStore = create<WindowStore>()(
         set((state) => {
           if (state.windows[id]) {
             state.activeWindowId = id;
+          }
+        }),
+
+      updateWindowTitle: (id, title) =>
+        set((state) => {
+          if (state.windows[id]) {
+            state.windows[id].caption = title;
           }
         }),
     })),

--- a/src/types/minihome.types.ts
+++ b/src/types/minihome.types.ts
@@ -1,8 +1,10 @@
 export const MINIHOME_TABS = {
-  HOME: "Home",
-  GALLERY: "Gallery",
-  MEMO: "Memo",
-  GUESTBOOK: "Guest Book",
+  home: "Home",
+  gallery: "Gallery",
+  memo: "Memo",
+  guestbook: "Guest Book",
 } as const;
 
 export type MiniHomeTabs = (typeof MINIHOME_TABS)[keyof typeof MINIHOME_TABS];
+
+export type MiniHomeTabId = keyof typeof MINIHOME_TABS;

--- a/src/types/window-app.type.ts
+++ b/src/types/window-app.type.ts
@@ -49,4 +49,4 @@ export const WINDOW_APPS = {
   },
 } as const;
 
-export type WindowApp = (typeof WINDOW_APPS)[keyof typeof WINDOW_APPS];
+export type WindowApps = (typeof WINDOW_APPS)[keyof typeof WINDOW_APPS];

--- a/src/types/window.types.ts
+++ b/src/types/window.types.ts
@@ -1,6 +1,8 @@
 import { type ComponentType, type FunctionComponent, type SVGProps } from "react";
 
-export type WindowAppId = "home" | "gallery" | "memo" | "guestbook" | "friends" | "settings";
+import type { MiniHomeTabId } from "@/types/minihome.types";
+
+export type WindowAppId = MiniHomeTabId | "friends" | "settings";
 
 export interface WindowApp {
   id: WindowAppId;

--- a/src/types/window.types.ts
+++ b/src/types/window.types.ts
@@ -1,0 +1,10 @@
+import { type ComponentType, type FunctionComponent, type SVGProps } from "react";
+
+export type WindowAppId = "home" | "gallery" | "memo" | "guestbook" | "friends" | "settings";
+
+export interface WindowApp {
+  id: WindowAppId;
+  caption: string;
+  icon: FunctionComponent<SVGProps<SVGSVGElement>>;
+  component?: ComponentType;
+}

--- a/src/types/window.types.ts
+++ b/src/types/window.types.ts
@@ -4,8 +4,11 @@ import type { MiniHomeTabId } from "@/types/minihome.types";
 
 export type WindowAppId = MiniHomeTabId | "friends" | "settings";
 
+export type WindowCategory = "minihome" | "friends" | "friendHome" | "settings";
+
 export interface WindowApp {
   id: WindowAppId;
+  category: WindowCategory;
   caption: string;
   icon: FunctionComponent<SVGProps<SVGSVGElement>>;
   component?: ComponentType;


### PR DESCRIPTION
## 📖 개요

동일 카테고리 윈도우 단독 실행 및 탭 상세 페이지 기능 구현

## ✅ 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- [x] 미니홈피 갤러리, 메모에서 상세 페이지로 갔을 경우 페이지 전환될 수 있는 로직 구현
- [x] 바탕화면 숏컷 클릭 시 같은 카테고리의 윈도우는 다중 윈도우가 아닌 단독 윈도우로 뜨도록 구현
- [x] useWindowStore, Window 관련 리팩토링  

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_
