### PR TITLE
feat(auth): 미니홈 윈도우가 실행될 때 ownerId를 통해 구분할 수 있는 기능 구현

### DIFF
--- a/src/components/minihome/guestbook/GuestBook.tsx
+++ b/src/components/minihome/guestbook/GuestBook.tsx
@@ -1,13 +1,17 @@
 import { X } from "lucide-react";
 
 import Button from "@/components/common/Button/Button";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 import GuestbookWriteBox from "./GuestbookWriteBox";
 
-export default function GuestBook() {
+export default function GuestBook({ ownerId }: { ownerId: string | undefined }) {
+  const user = useAuthStore((state) => state.user);
+  const isMine = ownerId === user?.id;
+
   return (
     <div className="p-4">
-      <GuestbookWriteBox />
+      {!isMine && <GuestbookWriteBox />}
       <div className="flex flex-col gap-1">
         <span className="p">전체 방명록 {3}</span>
         <div className="bevel-pressed bg-text-invert gap-2 p-3">

--- a/src/config/window.tsx
+++ b/src/config/window.tsx
@@ -6,7 +6,7 @@ import Memo from "@/assets/icons/memo.svg?react";
 import Settings from "@/assets/icons/settings.svg?react";
 import MiniHome from "@/pages/minihome/MiniHome";
 import { MINIHOME_TABS } from "@/types/minihome.types";
-import type { WindowApp, WindowAppId } from "@/types/window.types";
+import type { WindowApp, WindowAppId, WindowComponentProps } from "@/types/window.types";
 
 export const WINDOW_APPS: Record<WindowAppId, WindowApp> = {
   home: {
@@ -14,28 +14,30 @@ export const WINDOW_APPS: Record<WindowAppId, WindowApp> = {
     category: "minihome",
     caption: "Home",
     icon: Home,
-    component: MiniHome,
+    component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.home} />,
   },
   gallery: {
     id: "gallery",
     category: "minihome",
     caption: "Gallery",
     icon: Gallery,
-    component: () => <MiniHome tab={MINIHOME_TABS.gallery} />,
+    component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.gallery} />,
   },
   memo: {
     id: "memo",
     category: "minihome",
     caption: "Memo",
     icon: Memo,
-    component: () => <MiniHome tab={MINIHOME_TABS.memo} />,
+    component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.memo} />,
   },
   guestbook: {
     id: "guestbook",
     category: "minihome",
     caption: "Guest Book",
     icon: Guestbook,
-    component: () => <MiniHome tab={MINIHOME_TABS.guestbook} />,
+    component: (props: WindowComponentProps) => (
+      <MiniHome {...props} tab={MINIHOME_TABS.guestbook} />
+    ),
   },
   friends: {
     id: "friends",

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -5,6 +5,11 @@ import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
 
+interface MiniHomeProps {
+  ownerId?: string;
+  tab?: MiniHomeTabs;
+}
+
 function useDetailState<TabId>() {
   const [selectedId, setSelectedId] = useState<TabId | null>(null);
 
@@ -14,7 +19,7 @@ function useDetailState<TabId>() {
   return { selectedId, enterDetail, exitDetail };
 }
 
-export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeTabs }) {
+export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHomeProps) {
   const [activeTab, setActiveTab] = useState<MiniHomeTabs>(tab);
 
   const galleryDetail = useDetailState<string>();
@@ -60,7 +65,7 @@ export default function MiniHome({ tab = MINIHOME_TABS.home }: { tab?: MiniHomeT
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.guestbook}>
         <Activity>
-          <GuestBook />
+          <GuestBook ownerId={ownerId} />
         </Activity>
       </Tabs.Content>
     </Tabs.Root>

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -4,14 +4,17 @@ import Shortcut from "@/components/os/Shortcut/Shortcut";
 import Taskbar from "@/components/os/Taskbar/Taskbar";
 import Window from "@/components/window/Window/Window";
 import { WINDOW_APPS } from "@/config/window";
+import { useAuthStore } from "@/stores/useAuthStore";
 import { useWindowStore } from "@/stores/useWindowStore";
-import type { WindowAppId } from "@/types/window.types";
+import type { WindowAppId, WindowCategory } from "@/types/window.types";
 
 export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);
   const [selectedShortcutId, setSelectedShortcutId] = useState<string | null>(null);
   const [focusedShortcutId, setFocusedShortcutId] = useState<string | null>(null);
   const { windows, openWindow, closeWindow } = useWindowStore();
+  const user = useAuthStore((state) => state.user);
+  const ownerId = user?.id;
 
   const handleShortcutFocus = (id: string) => {
     setSelectedShortcutId(id);
@@ -22,8 +25,12 @@ export default function OsMain() {
     setSelectedShortcutId(null);
   };
 
-  const handleShortcutDoubleClick = (id: WindowAppId) => {
-    openWindow(id);
+  const handleShortcutDoubleClick = (id: WindowAppId, category: WindowCategory) => {
+    if (category === "minihome") {
+      openWindow(id, ownerId);
+    } else {
+      openWindow(id);
+    }
     setSelectedShortcutId(null);
     setFocusedShortcutId(null);
   };
@@ -35,7 +42,7 @@ export default function OsMain() {
           className="grid h-full w-full auto-cols-max grid-flow-row auto-rows-max gap-6 md:gap-8"
           aria-label="바로가기"
         >
-          {Object.values(WINDOW_APPS).map(({ id, icon, caption }) => (
+          {Object.values(WINDOW_APPS).map(({ id, icon, caption, category }) => (
             <Shortcut
               key={id}
               Icon={icon}
@@ -44,7 +51,7 @@ export default function OsMain() {
               isFocused={focusedShortcutId === id}
               onFocus={() => handleShortcutFocus(id)}
               onBlur={handleShortcutBlur}
-              onDoubleClick={() => handleShortcutDoubleClick(id)}
+              onDoubleClick={() => handleShortcutDoubleClick(id, category)}
             />
           ))}
         </div>
@@ -63,7 +70,7 @@ export default function OsMain() {
               title={windowState.caption}
               icon={windowState.icon}
             >
-              <Component />
+              <Component ownerId={windowState.ownerId} />
             </Window>
           );
         })}

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -8,7 +8,7 @@ import type { WindowApp, WindowAppId, WindowCategory } from "@/types/window.type
 interface WindowStore {
   windows: Partial<Record<WindowAppId, WindowApp>>;
   activeWindowId: WindowAppId | null;
-  openWindow: (id: WindowAppId) => void;
+  openWindow: (id: WindowAppId, ownerId?: string) => void;
   closeWindow: (id: WindowAppId) => void;
   setActiveWindow: (id: WindowAppId) => void;
   updateWindowTitle: (id: WindowAppId, title: string) => void;
@@ -31,7 +31,7 @@ export const useWindowStore = create<WindowStore>()(
       windows: {},
       activeWindowId: null,
 
-      openWindow: (id) =>
+      openWindow: (id, ownerId) =>
         set((state) => {
           const appConfig = WINDOW_APPS[id];
           if (!appConfig) return;
@@ -43,7 +43,7 @@ export const useWindowStore = create<WindowStore>()(
 
           clearWindowsByCategory(state.windows, appConfig.category);
 
-          state.windows[id] = { ...appConfig };
+          state.windows[id] = { ...appConfig, ownerId };
           state.activeWindowId = id;
         }),
 

--- a/src/types/window.types.ts
+++ b/src/types/window.types.ts
@@ -6,10 +6,15 @@ export type WindowAppId = MiniHomeTabId | "friends" | "settings";
 
 export type WindowCategory = "minihome" | "friends" | "friendHome" | "settings";
 
+export interface WindowComponentProps {
+  ownerId?: string;
+}
+
 export interface WindowApp {
   id: WindowAppId;
+  ownerId?: string;
   category: WindowCategory;
   caption: string;
   icon: FunctionComponent<SVGProps<SVGSVGElement>>;
-  component?: ComponentType;
+  component?: ComponentType<WindowComponentProps>;
 }


### PR DESCRIPTION
## 📖 개요

미니홈 윈도우가 실행될 때 ownerId를 통해 구분할 수 있는 기능 구현

## ✅ 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- [x] Window가 실행될 때 정보에 ownerId가 포함되도록 구현
- [x] 해당 ownerId가 미니홈의 각 탭에서 props로 받을 수 있도록 구현

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_