### PR TITLE
[#83] feat(guestbook): 방명록 전체 목록 및 isMine에 따라 조건부 렌더링 구현

### DIFF
--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -10,7 +10,7 @@ export default function TextArea({ id, maxLength = 2200, className, ...props }: 
       maxLength={maxLength}
       className={twMerge(
         "bevel-pressed bg-text-invert scrollbar w-full resize-none",
-        "disabled:disabled-base h-15 py-3 outline-none focus:border-none",
+        "disabled:disabled-base h-15 p-3 outline-none focus:border-none",
         className
       )}
       {...props}

--- a/src/components/minihome/guestbook/GuestBook.tsx
+++ b/src/components/minihome/guestbook/GuestBook.tsx
@@ -1,55 +1,75 @@
-import { X } from "lucide-react";
+import { useEffect, useState } from "react";
 
-import Button from "@/components/common/Button/Button";
 import { useAuthStore } from "@/stores/useAuthStore";
 
+import { fetchGuestbookWithComments } from "./api/guestbook";
+import CommentWriteBox from "./CommentWriteBox";
+import GuestBookEntry from "./GuestBookEntry";
 import GuestbookWriteBox from "./GuestbookWriteBox";
+import Reply from "./Reply";
+import type { GuestbookWithComments } from "./types/guestbook.types";
 
 export default function GuestBook({ ownerId }: { ownerId: string | undefined }) {
   const user = useAuthStore((state) => state.user);
-  const isMine = ownerId === user?.id;
+  const isMine = ownerId !== undefined && ownerId === user?.id;
+  const [data, setData] = useState<GuestbookWithComments[]>([]);
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // TODO: 이후 에러 핸들링 및 폴백 구현
+  const [error, setError] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!ownerId) return;
+
+    /*
+    TODO: API에서 throw error를 함으로 일단 try catch로 구현
+    이후 에러 핸들링 구현 시, return error 후 if error로 구현
+    */
+    const fetchGuestbookData = async () => {
+      try {
+        setIsLoading(true);
+        const fetchData = await fetchGuestbookWithComments(ownerId);
+        setData(fetchData);
+      } catch (err) {
+        console.error(err);
+        setError(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchGuestbookData();
+  }, [ownerId]);
 
   return (
-    <div className="p-4">
+    <div className="flex h-full min-h-0 flex-col p-4">
       {!isMine && <GuestbookWriteBox />}
-      <div className="flex flex-col gap-1">
-        <span className="p">전체 방명록 {3}</span>
-        <div className="bevel-pressed bg-text-invert gap-2 p-3">
-          <ul>
-            <li>
-              <div className="bevel-default flex w-full flex-col gap-2 p-4">
-                <div className="flex flex-col gap-2">
-                  <div className="flex justify-between">
-                    <span className="text-muted dark:text-primary">친구이름</span>
-                    <div className="flex gap-2">
-                      <span className="opacity-50">2025.11.10 10:30</span>
-                      <Button composition="iconOnly" size="sm" className="font-bold">
-                        <X size="1em" strokeWidth={3} />
-                      </Button>
-                    </div>
-                  </div>
-                  <p>
-                    내용내용내용내용내용내ㅛ용내요ㅐㄴ요ㅐㄴ요ㅐㄴ요내요ㅐㄴ요ㅐ뇨애뇨애뇨애뇨애뇨애뇨애뇨앤요ㅐ뇨애뇨애뇨애뇨애뇨애뇨애뇨애뇨애뇨애뇽
-                  </p>
-                </div>
-                <div className="border-primary border-l-3 pl-3">
-                  <div className="flex flex-col gap-2">
-                    <div className="flex justify-between">
-                      <span className="text-accent">친구이름</span>
-                      <div className="flex gap-2">
-                        <span className="opacity-50">2025.11.10 10:30</span>
-                        <Button composition="iconOnly" size="sm" className="font-bold">
-                          <X size="1em" strokeWidth={3} />
-                        </Button>
-                      </div>
-                    </div>
-                    <p>
-                      내용내용내용내용내용내ㅛ용내요ㅐㄴ요ㅐㄴ요ㅐㄴ요내요ㅐㄴ요ㅐ뇨애뇨애뇨애뇨애뇨애뇨애뇨앤요ㅐ뇨애뇨애뇨애뇨애뇨애뇨애뇨애뇨애뇨애뇽
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </li>
+      <div className="flex min-h-0 flex-1 flex-col gap-1">
+        <span className="p">전체 방명록 {data.length}</span>
+        <div className="bevel-pressed bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3">
+          <ul className="flex flex-col gap-2">
+            {data.map((entry) => (
+              <li key={entry.id}>
+                <GuestBookEntry
+                  id={entry.id}
+                  author={entry.author}
+                  created_at={entry.created_at}
+                  content={entry.content}
+                >
+                  {entry.comments.length > 0 ? (
+                    <Reply
+                      id={entry.comments[0].id}
+                      commenter={entry.comments[0].commenter}
+                      created_at={entry.comments[0].created_at}
+                      content={entry.comments[0].content}
+                    />
+                  ) : (
+                    isMine && <CommentWriteBox />
+                  )}
+                </GuestBookEntry>
+              </li>
+            ))}
           </ul>
         </div>
       </div>

--- a/src/components/minihome/guestbook/GuestBookEntry.tsx
+++ b/src/components/minihome/guestbook/GuestBookEntry.tsx
@@ -4,21 +4,25 @@ import type { ReactNode } from "react";
 
 import Button from "@/components/common/Button/Button";
 
-interface GuestBookEntryProps {
-  username: string;
-  date: string;
-  content: string;
-  children: ReactNode;
+import type { GuestBookEntryType } from "./types/guestbook.types";
+
+export interface GuestBookEntryProps extends GuestBookEntryType {
+  children?: ReactNode;
 }
 
-export default function GuestBookEntry({ username, date, content, children }: GuestBookEntryProps) {
+export default function GuestBookEntry({
+  author,
+  created_at,
+  content,
+  children,
+}: GuestBookEntryProps) {
   return (
     <div className="bevel-default flex w-full flex-col gap-2 p-4">
       <div className="flex flex-col gap-2">
         <div className="flex justify-between">
-          <span className="text-muted dark:text-primary">{username}</span>
+          <span className="text-muted dark:text-primary">{author?.nickname}</span>
           <div className="flex gap-2">
-            <span className="opacity-50">{dayjs(date).format("YYYY.MM.DD HH:mm")}</span>
+            <span className="opacity-50">{dayjs(created_at).format("YYYY.MM.DD HH:mm")}</span>
             <Button composition="iconOnly" size="sm" className="font-bold" aria-label="방명록 삭제">
               <X size="1em" strokeWidth={3} />
             </Button>

--- a/src/components/minihome/guestbook/Reply.tsx
+++ b/src/components/minihome/guestbook/Reply.tsx
@@ -3,21 +3,17 @@ import { X } from "lucide-react";
 
 import Button from "@/components/common/Button/Button";
 
-interface ReplyProps {
-  username: string;
-  date: string;
-  content: string;
-}
+import type { GuestbookCommentWithAuthor } from "./types/guestbook.types";
 
-export default function Reply({ username, date, content }: ReplyProps) {
+export default function Reply({ commenter, created_at, content }: GuestbookCommentWithAuthor) {
   return (
     <div className="border-primary border-l-3 pl-3">
       <div className="flex flex-col gap-2">
         <div className="flex justify-between">
-          <span className="text-accent">{username}</span>
+          <span className="text-accent">{commenter?.nickname}</span>
           <div className="flex gap-2">
-            <span className="opacity-50">{dayjs(date).format("YYYY.MM.DD HH:mm")}</span>
-            <Button composition="iconOnly" size="sm" className="font-bold" aria-label="답글 삭제">
+            <span className="opacity-50">{dayjs(created_at).format("YYYY.MM.DD HH:mm")}</span>
+            <Button composition="iconOnly" size="sm" aria-label="답글 삭제">
               <X size="1em" strokeWidth={3} />
             </Button>
           </div>

--- a/src/components/minihome/guestbook/api/guestbook.ts
+++ b/src/components/minihome/guestbook/api/guestbook.ts
@@ -1,0 +1,37 @@
+import supabase from "@/utils/supabase";
+
+export async function fetchGuestbookWithComments(ownerId: string) {
+  const { data, error } = await supabase
+    .from("guestbook_posts")
+    .select(
+      `
+      id,
+      created_at,
+      content,
+
+      homepage:homepages!inner (
+        owner_id
+      ),
+
+      author:profiles!guestbook_posts_author_id_fkey (
+        nickname
+      ),
+
+      comments:guestbook_comments (
+        id,
+        created_at,
+        content,
+
+        commenter:profiles!guestbook_comments_author_id_fkey (
+          nickname
+        )
+      )
+    `
+    )
+    .eq("homepage.owner_id", ownerId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  return data;
+}

--- a/src/components/minihome/guestbook/types/guestbook.types.ts
+++ b/src/components/minihome/guestbook/types/guestbook.types.ts
@@ -1,0 +1,36 @@
+import type { Database } from "@/types/database.types";
+
+type GuestbookPostRow = Database["public"]["Tables"]["guestbook_posts"]["Row"];
+type HomePageRow = Database["public"]["Tables"]["homepages"]["Row"];
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+type CommentRow = Database["public"]["Tables"]["guestbook_comments"]["Row"];
+
+export interface GuestbookWithComments {
+  id: GuestbookPostRow["id"];
+  created_at: GuestbookPostRow["created_at"];
+  content: GuestbookPostRow["content"];
+
+  homepage: {
+    owner_id: HomePageRow["owner_id"];
+  } | null;
+
+  author: {
+    nickname: ProfileRow["nickname"] | null;
+  } | null;
+
+  comments: GuestbookCommentWithAuthor[];
+}
+
+export type GuestBookEntryType = Pick<
+  GuestbookWithComments,
+  "id" | "created_at" | "content" | "author"
+>;
+
+export interface GuestbookCommentWithAuthor {
+  id: CommentRow["id"];
+  created_at: CommentRow["created_at"];
+  content: CommentRow["content"];
+  commenter: {
+    nickname: ProfileRow["nickname"] | null;
+  } | null;
+}

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -32,7 +32,11 @@ export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHome
   }, [activeTab]);
 
   return (
-    <Tabs.Root value={activeTab} onValueChange={(value) => setActiveTab(value as MiniHomeTabs)}>
+    <Tabs.Root
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as MiniHomeTabs)}
+      className="flex h-full min-h-0 flex-col"
+    >
       <Tabs.List aria-label="미니홈 탭">
         {Object.values(MINIHOME_TABS).map((v) => (
           <Tabs.Trigger key={v} value={v} asChild>
@@ -63,10 +67,8 @@ export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHome
           )} */}
         </Activity>
       </Tabs.Content>
-      <Tabs.Content value={MINIHOME_TABS.guestbook}>
-        <Activity>
-          <GuestBook ownerId={ownerId} />
-        </Activity>
+      <Tabs.Content value={MINIHOME_TABS.guestbook} asChild>
+        <GuestBook ownerId={ownerId} />
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -1,5 +1,5 @@
 @utility scrollbar {
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable;
 
   &::-webkit-scrollbar {
     width: var(--scrollbar-size);

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -83,26 +83,33 @@ export interface Database {
       guestbook_comments: {
         Row: {
           author_id: string;
-          content: Json | null;
+          content: string | null;
           created_at: string;
           id: string;
           post_id: string;
         };
         Insert: {
           author_id?: string;
-          content?: Json | null;
+          content?: string | null;
           created_at?: string;
           id?: string;
           post_id?: string;
         };
         Update: {
           author_id?: string;
-          content?: Json | null;
+          content?: string | null;
           created_at?: string;
           id?: string;
           post_id?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "guestbook_comments_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["auth_id"];
+          },
           {
             foreignKeyName: "guestbook_replies_author_id_fkey";
             columns: ["author_id"];
@@ -122,7 +129,7 @@ export interface Database {
       guestbook_posts: {
         Row: {
           author_id: string | null;
-          content: Json | null;
+          content: string | null;
           created_at: string;
           homepage_id: string;
           id: string;
@@ -130,7 +137,7 @@ export interface Database {
         };
         Insert: {
           author_id?: string | null;
-          content?: Json | null;
+          content?: string | null;
           created_at?: string;
           homepage_id: string;
           id?: string;
@@ -138,7 +145,7 @@ export interface Database {
         };
         Update: {
           author_id?: string | null;
-          content?: Json | null;
+          content?: string | null;
           created_at?: string;
           homepage_id?: string;
           id?: string;


### PR DESCRIPTION
## 📖 개요

방명록 전체 목록 및 isMine에 따라 조건부 렌더링 구현

## ✅ 관련 이슈

- Close #83 

## 🛠️ 상세 작업 내용

- [x] 방명록 및 댓글 목록을 테이블 조인으로 한 번에 데이터 Fetch 하도록 구현
- [x] 해당 미니홈이 자기의 미니홈일 때만 댓글이 없을 경우 Input, 없을 경우 댓글이 뜨도록 구현
- [x] 방명록 작성 TextArea가 본인의 미니홈이 아닐 경우에만 렌더링 되도록 구현

## 📸 스크린샷

<img width="611" height="521" alt="스크린샷 2025-11-18 04 25 57" src="https://github.com/user-attachments/assets/8578e0cb-be17-4813-a4b8-05d8703b60dd" />

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

삭제 버튼 조건부 렌더링 아직 미구현입니다.
