### PR TITLE
[#87] feat(window): 친구 홈 윈도우 추가 및 윈도우 관리 구조 리팩토링

### DIFF
--- a/src/assets/icons/friendhome.svg
+++ b/src/assets/icons/friendhome.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Interface-Essential-Home-1--Streamline-Pixel">
+  <desc>
+    Interface Essential Home 1 Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>interface-essential-home-1</title>
+  <g>
+    <path d="m6.855 13.71 0 -1.52 1.53 0 0 -1.52 1.52 0 0 -1.53 1.52 0 0 -1.52 1.53 0 0 -1.52 1.52 0 0 -1.53 3.05 0 0 1.53 1.52 0 0 1.52 1.53 0 0 1.52 1.52 0 0 1.53 1.52 0 0 1.52 1.53 0 0 1.52 1.52 0 0 16.77 1.53 0 0 -13.72 1.52 0 0 -1.52 1.52 0 0 -1.53 -1.52 0 0 -1.52 -1.52 0 0 -1.52 -1.53 0 0 -1.53 -1.52 0 0 -1.52 -1.53 0 0 -1.52 -1.52 0 0 -1.53 -1.52 0 0 -1.52 -1.53 0 0 -1.53 -1.52 0 0 -1.52 -3.05 0 0 1.52 -1.52 0 0 1.53 -1.53 0 0 1.52 -1.52 0 0 1.53 -1.52 0 0 1.52 -1.53 0 0 1.52 -1.52 0 0 1.53 -1.52 0 0 1.52 -1.53 0 0 1.52 -1.52 0 0 1.53 1.52 0 0 1.52 1.53 0 0 13.72 1.52 0 0 -16.77 1.52 0z" fill="currentColor" stroke-width="1"></path>
+    <path d="m26.665 32 0 -1.52 -6.09 0 0 -12.19 -1.53 0 0 12.19 -6.09 0 0 -12.19 -1.53 0 0 12.19 -6.09 0 0 1.52 21.33 0z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.095 19.81h3.05v3.05h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M17.525 9.14h1.52v3.05h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M14.475 7.62h3.05v1.52h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M14.475 22.86h1.53v1.52h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.955 16.76h6.09v1.53h-6.09Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M14.475 12.19h3.05v1.52h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.955 9.14h1.52v3.05h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.855 19.81h3.05v3.05h-3.05Z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/components/os/Taskbar/Taskbar.tsx
+++ b/src/components/os/Taskbar/Taskbar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { twMerge } from "tailwind-merge";
 
+import { WINDOW_APPS } from "@/config/window";
 import { useWindowStore } from "@/stores/useWindowStore";
 import type { WindowAppId } from "@/types/window.types";
 
@@ -48,11 +49,8 @@ type TaskbarProps = React.ComponentPropsWithoutRef<"nav"> & {
  * ```
  */
 export default function Taskbar({ className, config = "default", ...rest }: TaskbarProps) {
-  // Taskbar 탭으로 노출할 전체 창 목록
   const windows = useWindowStore((state) => state.windows);
-  // 현재 포커스된 창의 ID
   const activeWindowId = useWindowStore((state) => state.activeWindowId);
-  // 특정 창으로 포커스를 이동시키는 액션
   const setActiveWindow = useWindowStore((state) => state.setActiveWindow);
 
   const showStart = config === "default" || config === "noSystemTray";
@@ -67,16 +65,23 @@ export default function Taskbar({ className, config = "default", ...rest }: Task
     <nav className={twMerge(taskbar, className)} {...rest}>
       {showStart && <TaskbarStart />}
       <ul className="flex flex-1 items-center gap-1 overflow-hidden">
-        {Object.values(windows).map((window) => (
-          <li key={window.id} className="@container flex max-w-43 min-w-0 flex-1">
-            <TaskbarTab
-              icon={window.icon}
-              title={window.caption}
-              isFocused={window.id === activeWindowId}
-              onClick={() => handleTabClick(window.id)}
-            />
-          </li>
-        ))}
+        {Object.values(windows).map((window) => {
+          if (!window) return null;
+
+          const app = WINDOW_APPS[window.id];
+          if (!app) return null;
+
+          return (
+            <li key={window.id} className="@container flex max-w-43 min-w-0 flex-1">
+              <TaskbarTab
+                icon={app.icon}
+                title={window.caption ?? app.caption}
+                isFocused={window.id === activeWindowId}
+                onClick={() => handleTabClick(window.id)}
+              />
+            </li>
+          );
+        })}
       </ul>
       {showSystemTray && <TaskbarSystemTray />}
     </nav>

--- a/src/config/window.tsx
+++ b/src/config/window.tsx
@@ -1,3 +1,4 @@
+import UserHome from "@/assets/icons/friendhome.svg?react";
 import Users from "@/assets/icons/friends.svg?react";
 import Gallery from "@/assets/icons/gallery.svg?react";
 import Guestbook from "@/assets/icons/guestbook.svg?react";
@@ -9,48 +10,43 @@ import MiniHome from "@/pages/minihome/MiniHome";
 import { MINIHOME_TABS } from "@/types/minihome.types";
 import type { WindowApp, WindowAppId, WindowComponentProps } from "@/types/window.types";
 
+import { WINDOW_INFO } from "./windowInfo";
+
 export const WINDOW_APPS: Record<WindowAppId, WindowApp> = {
   home: {
-    id: "home",
-    category: "minihome",
-    caption: "Home",
+    ...WINDOW_INFO.home,
     icon: Home,
     component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.home} />,
   },
   gallery: {
-    id: "gallery",
-    category: "minihome",
-    caption: "Gallery",
+    ...WINDOW_INFO.gallery,
     icon: Gallery,
     component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.gallery} />,
   },
   memo: {
-    id: "memo",
-    category: "minihome",
-    caption: "Memo",
+    ...WINDOW_INFO.memo,
     icon: Memo,
     component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.memo} />,
   },
   guestbook: {
-    id: "guestbook",
-    category: "minihome",
-    caption: "Guest Book",
+    ...WINDOW_INFO.guestbook,
     icon: Guestbook,
     component: (props: WindowComponentProps) => (
       <MiniHome {...props} tab={MINIHOME_TABS.guestbook} />
     ),
   },
   friends: {
-    id: "friends",
-    category: "friends",
-    caption: "Friends",
+    ...WINDOW_INFO.friends,
     icon: Users,
     component: () => <Friends />,
   },
+  friendHome: {
+    ...WINDOW_INFO.friendHome,
+    icon: UserHome,
+    component: (props: WindowComponentProps) => <MiniHome {...props} tab={MINIHOME_TABS.home} />,
+  },
   settings: {
-    id: "settings",
-    category: "settings",
-    caption: "Settings",
+    ...WINDOW_INFO.settings,
     icon: Settings,
   },
 } as const;

--- a/src/config/windowInfo.tsx
+++ b/src/config/windowInfo.tsx
@@ -1,0 +1,53 @@
+import type { WindowAppId, WindowCategory } from "@/types/window.types";
+
+export interface WindowInfo {
+  id: WindowAppId;
+  category: WindowCategory;
+  caption: string;
+  isOnDesktop: boolean;
+}
+
+export const WINDOW_INFO: Record<WindowAppId, WindowInfo> = {
+  home: {
+    id: "home",
+    category: "minihome",
+    caption: "Home",
+    isOnDesktop: true,
+  },
+  gallery: {
+    id: "gallery",
+    category: "minihome",
+    caption: "Gallery",
+    isOnDesktop: true,
+  },
+  memo: {
+    id: "memo",
+    category: "minihome",
+    caption: "Memo",
+    isOnDesktop: true,
+  },
+  guestbook: {
+    id: "guestbook",
+    category: "minihome",
+    caption: "Guest Book",
+    isOnDesktop: true,
+  },
+  friends: {
+    id: "friends",
+    category: "friends",
+    caption: "Friends",
+    isOnDesktop: true,
+  },
+  friendHome: {
+    id: "friendHome",
+    category: "friendHome",
+    caption: "Friend Home",
+    isOnDesktop: false,
+  },
+  settings: {
+    id: "settings",
+    category: "settings",
+    caption: "Settings",
+    isOnDesktop: false,
+  },
+} as const;

--- a/src/pages/friends/Search.tsx
+++ b/src/pages/friends/Search.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
+import { useAuthStore } from "@/stores/useAuthStore";
+import { useWindowStore } from "@/stores/useWindowStore";
 import type { Profile } from "@/types/profile";
 
 import { searchFriends } from "./api/searchFriends";
@@ -10,6 +12,8 @@ export default function Search() {
   const [keyword, setKeyword] = useState("");
   const [results, setResults] = useState<Profile[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
+  const openWindow = useWindowStore((state) => state.openWindow);
+  const userId = useAuthStore((state) => state.user?.id);
   /* eslint-disable @typescript-eslint/no-unused-vars */
   // TODO: 이후 에러 핸들링 및 폴백 구현
   const [error, setError] = useState(false);
@@ -24,7 +28,7 @@ export default function Search() {
     */
     try {
       setIsLoading(true);
-      const data = await searchFriends(keyword);
+      const data = await searchFriends(keyword, userId);
       setResults(data);
       setHasSearched(true);
     } catch (err) {
@@ -67,7 +71,7 @@ export default function Search() {
           <div className="bevel-pressed bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3">
             <ul>
               {results.map((user) => (
-                <li>
+                <li key={user.auth_id}>
                   <div className="flex items-center gap-3 p-2 pl-2 select-none">
                     <div className="shrink-0">
                       <img
@@ -86,7 +90,7 @@ export default function Search() {
                       <Button
                         size="md"
                         onClick={() => {
-                          // TODO: 미니홈 방문 기능
+                          openWindow("friendHome", user.auth_id);
                         }}
                       >
                         방문

--- a/src/pages/friends/api/searchFriends.ts
+++ b/src/pages/friends/api/searchFriends.ts
@@ -1,10 +1,11 @@
 import supabase from "@/utils/supabase";
 
-export async function searchFriends(keyword: string) {
+export async function searchFriends(keyword: string, userId: string) {
   const { data, error } = await supabase
     .from("profiles")
     .select("*")
-    .or(`nickname.ilike.%${keyword}%, email.ilike.%${keyword}%`);
+    .or(`nickname.ilike.%${keyword}%, email.ilike.%${keyword}%`)
+    .neq("auth_id", userId);
 
   if (error) throw error;
 

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -12,7 +12,10 @@ export default function OsMain() {
   const ref = useRef<HTMLElement | null>(null);
   const [selectedShortcutId, setSelectedShortcutId] = useState<string | null>(null);
   const [focusedShortcutId, setFocusedShortcutId] = useState<string | null>(null);
-  const { windows, openWindow, closeWindow } = useWindowStore();
+  const windows = useWindowStore((state) => state.windows);
+  const openWindow = useWindowStore((state) => state.openWindow);
+  const closeWindow = useWindowStore((state) => state.closeWindow);
+
   const user = useAuthStore((state) => state.user);
   const ownerId = user?.id;
 
@@ -42,23 +45,29 @@ export default function OsMain() {
           className="grid h-full w-full auto-cols-max grid-flow-row auto-rows-max gap-6 md:gap-8"
           aria-label="바로가기"
         >
-          {Object.values(WINDOW_APPS).map(({ id, icon, caption, category }) => (
-            <Shortcut
-              key={id}
-              Icon={icon}
-              caption={caption}
-              isSelected={selectedShortcutId === id}
-              isFocused={focusedShortcutId === id}
-              onFocus={() => handleShortcutFocus(id)}
-              onBlur={handleShortcutBlur}
-              onDoubleClick={() => handleShortcutDoubleClick(id, category)}
-            />
-          ))}
+          {Object.values(WINDOW_APPS).map(({ id, icon, caption, category, isOnDesktop }) =>
+            !isOnDesktop ? null : (
+              <Shortcut
+                key={id}
+                Icon={icon}
+                caption={caption}
+                isSelected={selectedShortcutId === id}
+                isFocused={focusedShortcutId === id}
+                onFocus={() => handleShortcutFocus(id)}
+                onBlur={handleShortcutBlur}
+                onDoubleClick={() => handleShortcutDoubleClick(id, category)}
+              />
+            )
+          )}
         </div>
 
         {Object.values(windows).map((windowState) => {
-          const Component = windowState.component;
-          if (!Component) return null;
+          if (!windowState) return null;
+
+          const app = WINDOW_APPS[windowState.id];
+          if (!app || !app.component) return null;
+
+          const Component = app.component;
 
           return (
             <Window
@@ -68,7 +77,7 @@ export default function OsMain() {
               buttons="all"
               onClose={() => closeWindow(windowState.id)}
               title={windowState.caption}
-              icon={windowState.icon}
+              icon={app.icon}
             >
               <Component ownerId={windowState.ownerId} />
             </Window>

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -2,11 +2,18 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
-import { WINDOW_APPS } from "@/config/window";
-import type { WindowApp, WindowAppId, WindowCategory } from "@/types/window.types";
+import { WINDOW_INFO } from "@/config/windowInfo";
+import type { WindowAppId, WindowCategory } from "@/types/window.types";
+
+interface WindowInstance {
+  id: WindowAppId;
+  category: WindowCategory;
+  caption: string;
+  ownerId?: string;
+}
 
 interface WindowStore {
-  windows: Partial<Record<WindowAppId, WindowApp>>;
+  windows: Partial<Record<WindowAppId, WindowInstance>>;
   activeWindowId: WindowAppId | null;
   openWindow: (id: WindowAppId, ownerId?: string) => void;
   closeWindow: (id: WindowAppId) => void;
@@ -15,14 +22,16 @@ interface WindowStore {
 }
 
 const clearWindowsByCategory = (
-  windows: Partial<Record<WindowAppId, WindowApp>>,
+  windows: Partial<Record<WindowAppId, WindowInstance>>,
   category: WindowCategory
 ) => {
   const idsToDelete = Object.values(windows)
     .filter((window) => window?.category === category)
     .map((window) => window.id);
 
-  idsToDelete.forEach((id) => delete windows[id]);
+  idsToDelete.forEach((id) => {
+    if (id) delete windows[id];
+  });
 };
 
 export const useWindowStore = create<WindowStore>()(
@@ -33,17 +42,22 @@ export const useWindowStore = create<WindowStore>()(
 
       openWindow: (id, ownerId) =>
         set((state) => {
-          const appConfig = WINDOW_APPS[id];
-          if (!appConfig) return;
+          const info = WINDOW_INFO[id];
+          if (!info) return;
 
           if (state.windows[id]) {
             state.activeWindowId = id;
             return;
           }
 
-          clearWindowsByCategory(state.windows, appConfig.category);
+          clearWindowsByCategory(state.windows, info.category);
 
-          state.windows[id] = { ...appConfig, ownerId };
+          state.windows[id] = {
+            id,
+            category: info.category,
+            caption: info.caption,
+            ownerId,
+          };
           state.activeWindowId = id;
         }),
 

--- a/src/types/window.types.ts
+++ b/src/types/window.types.ts
@@ -2,7 +2,7 @@ import { type ComponentType, type FunctionComponent, type SVGProps } from "react
 
 import type { MiniHomeTabId } from "@/types/minihome.types";
 
-export type WindowAppId = MiniHomeTabId | "friends" | "settings";
+export type WindowAppId = MiniHomeTabId | "friends" | "friendHome" | "settings";
 
 export type WindowCategory = "minihome" | "friends" | "friendHome" | "settings";
 
@@ -17,4 +17,5 @@ export interface WindowApp {
   caption: string;
   icon: FunctionComponent<SVGProps<SVGSVGElement>>;
   component?: ComponentType<WindowComponentProps>;
+  isOnDesktop: boolean;
 }


### PR DESCRIPTION
## 📖 개요

친구 홈 윈도우 추가 및 윈도우 관리 구조 리팩토링

## ✅ 관련 이슈

- Close #87 

## 🛠️ 상세 작업 내용

- [x] friendHome 윈도우 타입 추가 및 아이콘/설정 구성
- [x] windowInfo로 정적 윈도우 정보 분리하여 관리 구조 개선
- [x] WindowStore는 윈도우 인스턴스 정보만 관리하도록 리팩토링
- [x] Taskbar와 OsMain에서 WINDOW_APPS 기반으로 UI 렌더링하도록 수정
- [x] 데스크탑 표시 여부(isOnDesktop)에 따라 바로가기 아이콘 렌더링
- [x] 친구 검색 시 현재 사용자 제외 처리
- [x] 검색 결과에서 friendHome 윈도우를 열 수 있도록 기능 추가

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

리팩토링으로 윈도우 관련 구조가 많이 바뀌었습니다.
