### PR TITLE
[#88] feat(window): Active 윈도우 z-index 구현 및 prop 전달 구조 개선

### DIFF
--- a/src/components/window/Window/Window.tsx
+++ b/src/components/window/Window/Window.tsx
@@ -7,6 +7,7 @@ import TitleBar, { type TitleBarProps } from "../TitleBar/TitleBar";
 interface WindowProps extends Dialog.DialogProps, TitleBarProps {
   ref: RefObject<HTMLElement | null>;
   description?: string | undefined;
+  isActive?: boolean;
 }
 
 export default function Window({
@@ -18,6 +19,7 @@ export default function Window({
   description,
   children,
   ref,
+  isActive,
   className,
 }: WindowProps) {
   return (
@@ -31,6 +33,7 @@ export default function Window({
               "md:h-[500px] md:w-[600px]",
               // TODO: 드래그 시 변경
               "md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2",
+              isActive ? "z-999" : "z-10",
               className
             )}
           >

--- a/src/config/windowInfo.tsx
+++ b/src/config/windowInfo.tsx
@@ -1,11 +1,4 @@
-import type { WindowAppId, WindowCategory } from "@/types/window.types";
-
-export interface WindowInfo {
-  id: WindowAppId;
-  category: WindowCategory;
-  caption: string;
-  isOnDesktop: boolean;
-}
+import type { WindowAppId, WindowInfo } from "@/types/window.types";
 
 export const WINDOW_INFO: Record<WindowAppId, WindowInfo> = {
   home: {

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -15,6 +15,8 @@ export default function OsMain() {
   const windows = useWindowStore((state) => state.windows);
   const openWindow = useWindowStore((state) => state.openWindow);
   const closeWindow = useWindowStore((state) => state.closeWindow);
+  const setActiveWindow = useWindowStore((state) => state.setActiveWindow);
+  const activeWindowId = useWindowStore((state) => state.activeWindowId);
 
   const user = useAuthStore((state) => state.user);
   const ownerId = user?.id;
@@ -68,6 +70,7 @@ export default function OsMain() {
           if (!app || !app.component) return null;
 
           const Component = app.component;
+          const isActive = windowState.id === activeWindowId;
 
           return (
             <Window
@@ -78,8 +81,10 @@ export default function OsMain() {
               onClose={() => closeWindow(windowState.id)}
               title={windowState.caption}
               icon={app.icon}
+              isActive={isActive}
+              onPointerDown={() => setActiveWindow(windowState.id)}
             >
-              <Component ownerId={windowState.ownerId} />
+              <Component windowId={windowState.id} ownerId={windowState.ownerId} />
             </Window>
           );
         })}

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -3,14 +3,7 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { WINDOW_INFO } from "@/config/windowInfo";
-import type { WindowAppId, WindowCategory } from "@/types/window.types";
-
-interface WindowInstance {
-  id: WindowAppId;
-  category: WindowCategory;
-  caption: string;
-  ownerId?: string;
-}
+import type { WindowAppId, WindowCategory, WindowInstance } from "@/types/window.types";
 
 interface WindowStore {
   windows: Partial<Record<WindowAppId, WindowInstance>>;

--- a/src/types/window.types.ts
+++ b/src/types/window.types.ts
@@ -1,4 +1,4 @@
-import { type ComponentType, type FunctionComponent, type SVGProps } from "react";
+import type { ComponentType, FunctionComponent, SVGProps } from "react";
 
 import type { MiniHomeTabId } from "@/types/minihome.types";
 
@@ -7,15 +7,25 @@ export type WindowAppId = MiniHomeTabId | "friends" | "friendHome" | "settings";
 export type WindowCategory = "minihome" | "friends" | "friendHome" | "settings";
 
 export interface WindowComponentProps {
+  windowId?: WindowAppId;
   ownerId?: string;
 }
 
-export interface WindowApp {
+export interface WindowInfo {
   id: WindowAppId;
-  ownerId?: string;
   category: WindowCategory;
   caption: string;
+  isOnDesktop: boolean;
+}
+
+export interface WindowApp extends WindowInfo {
   icon: FunctionComponent<SVGProps<SVGSVGElement>>;
   component?: ComponentType<WindowComponentProps>;
-  isOnDesktop: boolean;
+}
+
+export interface WindowInstance {
+  id: WindowAppId;
+  category: WindowCategory;
+  caption: string;
+  ownerId?: string;
 }


### PR DESCRIPTION
## 📖 개요

Active 윈도우 z-index 구현 및 prop 전달 구조 개선

## ✅ 관련 이슈

- Close #88 

## 🛠️ 상세 작업 내용

- [x] Window 컴포넌트에 isActive prop을 도입하여 z-index 기반 활성 상태 강조 기능 추가
- [x] pointer down 시 창 활성화되도록 로직 개선 및 windowId 전달 처리
- [x] Friends 컴포넌트가 props를 수용하고 하위로 전달할 수 있도록 구조 리팩토링
- [x] Window 관련 타입 정의를 정리하여 일관성과 타입 안정성 강화

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_