### PR TITLE
[#77] feat(gallery): 갤러리 컴포넌트 UI 구현

### DIFF
--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
+
 import Button from "@/components/common/Button/Button";
 
-// 임시 아이콘 컴포넌트 (이미지 플레이스홀더)
 const ImagePlaceholder = () => (
   <div className="flex h-full w-full items-center justify-center">
     <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -14,21 +15,24 @@ const ImagePlaceholder = () => (
   </div>
 );
 
-export default function Gallery() {
-  // 임시 이미지 데이터 (20개)
-  const images = Array.from({ length: 20 }, (_, i) => i + 1);
+interface GalleryProps {
+  onUpload: () => void;
+}
+
+export default function Gallery({ onUpload }: GalleryProps) {
+  const images = useMemo(() => Array.from({ length: 8 }, (_, i) => i + 1), []);
 
   return (
-    <div className="bevel-default flex h-full w-full flex-col overflow-hidden p-7">
-      <div className="bevel-pressed h-[360px] w-full overflow-hidden p-1">
+    <div className="flex h-full w-full flex-col overflow-hidden p-7">
+      <div className="bevel-pressed flex-1 overflow-hidden p-1">
         <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
-          {/* 헤더 */}
           <div className="flex items-center justify-between">
             <h1 className="font-semibold">사진첩</h1>
-            <Button composition="textOnly">업로드</Button>
+            <Button composition="textOnly" onClick={onUpload}>
+              업로드
+            </Button>
           </div>
 
-          {/* 사진 그리드 */}
           <div className="mt-2 grid grid-cols-4 gap-1">
             {images.map((image) => (
               <div key={image} className="bevel-default aspect-square w-full overflow-hidden p-1">

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -17,15 +17,18 @@ const ImagePlaceholder = () => (
 
 interface GalleryProps {
   onUpload: () => void;
+  onSelectImage: (id: number) => void;
 }
 
-export default function Gallery({ onUpload }: GalleryProps) {
-  const images = useMemo(() => Array.from({ length: 8 }, (_, i) => i + 1), []);
+export default function Gallery({ onUpload, onSelectImage }: GalleryProps) {
+  const images = useMemo(() => Array.from({ length: 20 }, (_, i) => i + 1), []);
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden p-7">
+      {/* 스크롤 가능한 사진 목록 영역 */}
       <div className="bevel-pressed flex-1 overflow-hidden p-1">
         <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
+          {/* 제목, 업로드 버튼 */}
           <div className="flex items-center justify-between">
             <h1 className="font-semibold">사진첩</h1>
             <Button composition="textOnly" onClick={onUpload}>
@@ -33,13 +36,19 @@ export default function Gallery({ onUpload }: GalleryProps) {
             </Button>
           </div>
 
+          {/* 사진 썸네일 그리드 */}
           <div className="mt-2 grid grid-cols-4 gap-1">
             {images.map((image) => (
-              <div key={image} className="bevel-default aspect-square w-full overflow-hidden p-1">
+              <button
+                key={image}
+                type="button"
+                className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
+                onClick={() => onSelectImage(image)}
+              >
                 <div className="h-full w-full">
                   <ImagePlaceholder />
                 </div>
-              </div>
+              </button>
             ))}
           </div>
         </div>

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,0 +1,45 @@
+import Button from "@/components/common/Button/Button";
+
+// 임시 아이콘 컴포넌트 (이미지 플레이스홀더)
+const ImagePlaceholder = () => (
+  <div className="flex h-full w-full items-center justify-center">
+    <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="Mdi4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+      />
+    </svg>
+  </div>
+);
+
+export default function Gallery() {
+  // 임시 이미지 데이터 (20개)
+  const images = Array.from({ length: 20 }, (_, i) => i + 1);
+
+  return (
+    <div className="bevel-default flex h-full w-full flex-col overflow-hidden p-7">
+      <div className="bevel-pressed h-[360px] w-full overflow-hidden p-1">
+        <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
+          {/* 헤더 */}
+          <div className="flex items-center justify-between">
+            <h1 className="font-semibold">사진첩</h1>
+            <Button composition="textOnly">업로드</Button>
+          </div>
+
+          {/* 사진 그리드 */}
+          <div className="mt-2 grid grid-cols-4 gap-1">
+            {images.map((image) => (
+              <div key={image} className="bevel-default aspect-square w-full overflow-hidden p-1">
+                <div className="h-full w-full">
+                  <ImagePlaceholder />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,6 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import Button from "@/components/common/Button/Button";
+import { useAuthStore } from "@/stores/useAuthStore";
+
+import GalleryDetailPanel from "./GalleryDetailPanel";
+import GalleryUploadPanel from "./GalleryUploadPanel";
 
 const ImagePlaceholder = () => (
   <div className="flex h-full w-full items-center justify-center">
@@ -16,43 +20,81 @@ const ImagePlaceholder = () => (
 );
 
 interface GalleryProps {
-  onUpload: () => void;
-  onSelectImage: (id: number) => void;
+  ownerId?: string;
 }
 
-export default function Gallery({ onUpload, onSelectImage }: GalleryProps) {
+type GalleryView = "list" | "detail" | "upload";
+
+export default function Gallery({ ownerId }: GalleryProps) {
+  const [view, setView] = useState<GalleryView>("list");
+  const [selectedImageId, setSelectedImageId] = useState<number | null>(null);
+  const userId = useAuthStore((state) => state.user?.id);
+  const canManageGallery = ownerId !== undefined && ownerId === userId;
+
   const images = useMemo(() => Array.from({ length: 20 }, (_, i) => i + 1), []);
+
+  const handleSelectImage = (imageId: number) => {
+    setSelectedImageId(imageId);
+    setView("detail");
+  };
+
+  const handleRequestUpload = () => {
+    if (!canManageGallery) return;
+    setView("upload");
+  };
+
+  const handleBackToList = () => {
+    setView("list");
+    setSelectedImageId(null);
+  };
+
+  const renderListView = () => (
+    // 베벨 테두리 래퍼
+    <div className="bevel-pressed h-full w-full overflow-hidden p-1">
+      {/* 내부 컨텐츠 */}
+      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
+        <div className="flex items-center justify-between">
+          <h1>사진첩</h1>
+          {canManageGallery && (
+            <Button composition="textOnly" onClick={handleRequestUpload}>
+              업로드
+            </Button>
+          )}
+        </div>
+
+        <div className="mt-2 grid grid-cols-4 gap-1">
+          {images.map((image) => (
+            <button
+              key={image}
+              type="button"
+              className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
+              onClick={() => handleSelectImage(image)}
+            >
+              <div className="h-full w-full">
+                <ImagePlaceholder />
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderContent = () => {
+    if (view === "detail" && selectedImageId !== null) {
+      return <GalleryDetailPanel imageId={selectedImageId} onBack={handleBackToList} />;
+    }
+
+    if (view === "upload" && canManageGallery) {
+      return <GalleryUploadPanel onCancel={handleBackToList} />;
+    }
+
+    return renderListView();
+  };
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden p-7">
-      {/* 스크롤 가능한 사진 목록 영역 */}
-      <div className="bevel-pressed flex-1 overflow-hidden p-1">
-        <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
-          {/* 제목, 업로드 버튼 */}
-          <div className="flex items-center justify-between">
-            <h1 className="font-semibold">사진첩</h1>
-            <Button composition="textOnly" onClick={onUpload}>
-              업로드
-            </Button>
-          </div>
-
-          {/* 사진 썸네일 그리드 */}
-          <div className="mt-2 grid grid-cols-4 gap-1">
-            {images.map((image) => (
-              <button
-                key={image}
-                type="button"
-                className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
-                onClick={() => onSelectImage(image)}
-              >
-                <div className="h-full w-full">
-                  <ImagePlaceholder />
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
+      <div className="h-full w-full">{renderContent()}</div>
     </div>
   );
 }

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -63,13 +63,10 @@ const ImagePlaceholder = () => (
 );
 
 export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPanelProps) {
-  const [likedComments, setLikedComments] = useState<Record<number, boolean>>({});
   const [photoLiked, setPhotoLiked] = useState(false);
   const description =
     MOCK_DESCRIPTIONS[(imageId - 1) % MOCK_DESCRIPTIONS.length] ?? "설명이 없습니다.";
-  const toggleLike = (commentId: number) => {
-    setLikedComments((prev) => ({ ...prev, [commentId]: !prev[commentId] }));
-  };
+
   const togglePhotoLike = () => setPhotoLiked((prev) => !prev);
 
   return (
@@ -129,43 +126,26 @@ export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPan
           <section className="bevel-pressed bg-text-invert flex w-full flex-col gap-4 p-4">
             <div className="space-y-4">
               <p>댓글 4개</p>
-              {MOCK_COMMENTS.map((comment) => {
-                const isLiked = Boolean(likedComments[comment.id]);
-                return (
-                  <div key={comment.id} className="bevel-default bg-text-invert p-3">
-                    <div className="flex items-start gap-3">
-                      <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
-                        {comment.avatarUrl ? (
-                          <img src={comment.avatarUrl} alt={`${comment.nickname} avatar`} />
-                        ) : (
-                          comment.nickname.charAt(0)
-                        )}
+              {MOCK_COMMENTS.map((comment) => (
+                <div key={comment.id} className="bevel-default bg-text-invert p-3">
+                  <div className="flex items-start gap-3">
+                    <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
+                      {comment.avatarUrl ? (
+                        <img src={comment.avatarUrl} alt={`${comment.nickname} avatar`} />
+                      ) : (
+                        comment.nickname.charAt(0)
+                      )}
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-muted mb-1 flex items-center justify-between">
+                        <span className="text-primary font-semibold">{comment.nickname}</span>
+                        <span>{comment.timeAgo}</span>
                       </div>
-                      <div className="flex-1">
-                        <div className="text-muted mb-1 flex items-center justify-between">
-                          <span className="text-primary font-semibold">{comment.nickname}</span>
-                          <span>{comment.timeAgo}</span>
-                        </div>
-                        <p>{comment.caption}</p>
-                        <button
-                          type="button"
-                          onClick={() => toggleLike(comment.id)}
-                          className={twMerge(
-                            "text-muted mt-2 flex cursor-pointer items-center gap-1 text-xs transition-colors",
-                            isLiked && "text-accent"
-                          )}
-                        >
-                          <Heart
-                            className={twMerge("h-3.5 w-3.5", isLiked && "fill-current")}
-                            fill={isLiked ? "currentColor" : "none"}
-                          />
-                          <span>좋아요 5</span>
-                        </button>
-                      </div>
+                      <p>{comment.caption}</p>
                     </div>
                   </div>
-                );
-              })}
+                </div>
+              ))}
             </div>
           </section>
         </div>

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -1,0 +1,179 @@
+import { ChevronLeft, Heart } from "lucide-react";
+import { useState } from "react";
+import { twMerge } from "tailwind-merge";
+
+import Button from "@/components/common/Button/Button";
+import Input from "@/components/common/Input/Input";
+
+interface GalleryDetailPanelProps {
+  imageId: number;
+  onBack: () => void;
+}
+
+const MOCK_COMMENTS = [
+  {
+    id: 1,
+    nickname: "일촌친구1",
+    timeAgo: "1시간 전",
+    caption: "사진 너무 이쁘다!",
+    avatarUrl: "https://picsum.photos/seed/friend1/80",
+  },
+  {
+    id: 2,
+    nickname: "일촌친구2",
+    timeAgo: "2시간 전",
+    caption: "여기 어디예요? 나도 가고싶다 ㅠㅠ",
+    avatarUrl: "https://picsum.photos/seed/friend2/80",
+  },
+  {
+    id: 3,
+    nickname: "일촌친구3",
+    timeAgo: "3시간 전",
+    caption: "날씨 좋은 날들이 최고지~",
+    avatarUrl: "https://picsum.photos/seed/friend3/80",
+  },
+  {
+    id: 4,
+    nickname: "도토리",
+    timeAgo: "4시간 전",
+    caption: "다들 고마워요! 다음에 같이 가요 ㅎㅎ",
+    avatarUrl: "https://picsum.photos/seed/dotori/80",
+  },
+];
+
+const MOCK_DESCRIPTIONS = [
+  "친구들이랑 제주도 다녀왔어요~",
+  "전시회에서 찍은 감성 사진이에요.",
+  "퇴근길 하늘이 예뻐서 한 컷!",
+  "주말마다 산책하는 우리 동네 산책로.",
+];
+
+const ImagePlaceholder = () => (
+  <div className="bg-surface flex h-full w-full items-center justify-center">
+    <svg className="text-muted h-16 w-16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2z"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 11l3 3 5-5 3 3" />
+    </svg>
+  </div>
+);
+
+export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPanelProps) {
+  const [likedComments, setLikedComments] = useState<Record<number, boolean>>({});
+  const [photoLiked, setPhotoLiked] = useState(false);
+  const description =
+    MOCK_DESCRIPTIONS[(imageId - 1) % MOCK_DESCRIPTIONS.length] ?? "설명이 없습니다.";
+  const toggleLike = (commentId: number) => {
+    setLikedComments((prev) => ({ ...prev, [commentId]: !prev[commentId] }));
+  };
+  const togglePhotoLike = () => setPhotoLiked((prev) => !prev);
+
+  return (
+    // 전체 컨테이너
+    <div className="relative flex h-full w-full flex-col overflow-hidden pb-7">
+      {/* 상단 고정 뒤로가기 버튼 */}
+      <Button
+        size="sm"
+        composition="iconOnly"
+        onClick={onBack}
+        className="bg-base-2 absolute"
+        aria-label="뒤로 가기"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      {/* 스크롤 가능한 본문 영역 */}
+      <div className="flex-1 overflow-hidden">
+        <div className="scrollbar flex h-full w-full flex-col gap-4 overflow-y-auto p-2">
+          {/* 이미지 표시 영역 */}
+          <section className="flex w-full flex-col items-center gap-4 p-4">
+            <div className="w-full overflow-hidden">
+              <div className="aspect-square h-full w-full overflow-hidden">
+                <ImagePlaceholder />
+              </div>
+            </div>
+
+            <div className="border-primary/30 mt-3 w-full border-t pt-3 text-left">
+              <p>{description}</p>
+              <span className="text-muted">2024.11.10 14:30</span>
+            </div>
+
+            <div className="border-primary/20 flex w-full flex-wrap items-center justify-between pt-3">
+              <Button
+                size="sm"
+                composition="iconText"
+                onClick={togglePhotoLike}
+                className={twMerge("text-primary px-3", photoLiked && "text-accent")}
+              >
+                <Heart
+                  className={twMerge("h-3.5 w-3.5", photoLiked && "text-accent fill-current")}
+                  fill={photoLiked ? "currentColor" : "none"}
+                />
+                좋아요 4
+              </Button>
+              <div className="flex items-center gap-2">
+                <Button size="sm" composition="textOnly" className="text-primary px-3">
+                  수정
+                </Button>
+                <Button size="sm" composition="textOnly" className="text-primary px-3">
+                  삭제
+                </Button>
+              </div>
+            </div>
+          </section>
+
+          {/* 댓글 영역 */}
+          <section className="bevel-pressed bg-text-invert flex w-full flex-col gap-4 p-4">
+            <div className="space-y-4">
+              <p>댓글 4개</p>
+              {MOCK_COMMENTS.map((comment) => {
+                const isLiked = Boolean(likedComments[comment.id]);
+                return (
+                  <div key={comment.id} className="bevel-default bg-text-invert p-3">
+                    <div className="flex items-start gap-3">
+                      <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
+                        {comment.avatarUrl ? (
+                          <img src={comment.avatarUrl} alt={`${comment.nickname} avatar`} />
+                        ) : (
+                          comment.nickname.charAt(0)
+                        )}
+                      </div>
+                      <div className="flex-1">
+                        <div className="text-muted mb-1 flex items-center justify-between">
+                          <span className="text-primary font-semibold">{comment.nickname}</span>
+                          <span>{comment.timeAgo}</span>
+                        </div>
+                        <p>{comment.caption}</p>
+                        <button
+                          type="button"
+                          onClick={() => toggleLike(comment.id)}
+                          className={twMerge(
+                            "text-muted mt-2 flex cursor-pointer items-center gap-1 text-xs transition-colors",
+                            isLiked && "text-accent"
+                          )}
+                        >
+                          <Heart
+                            className={twMerge("h-3.5 w-3.5", isLiked && "fill-current")}
+                            fill={isLiked ? "currentColor" : "none"}
+                          />
+                          <span>좋아요 5</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </div>
+      <div className="mt-4 flex shrink-0 items-center gap-2 px-4">
+        <Input placeholder="댓글을 입력하세요..." aria-label="댓글 입력" />
+        <Button composition="textOnly">등록</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -71,7 +71,7 @@ export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPan
 
   return (
     // 전체 컨테이너
-    <div className="relative flex h-full w-full flex-col overflow-hidden pb-7">
+    <div className="relative flex h-full w-full flex-col overflow-hidden">
       {/* 상단 고정 뒤로가기 버튼 */}
       <Button
         size="sm"

--- a/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
+++ b/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
@@ -42,6 +42,7 @@ export default function GalleryUploadFileSelector({
 
   return (
     <div className="space-y-3">
+      {/* 이미지 프리뷰 카드 */}
       <div className="bevel-pressed bg-text-invert text-muted flex flex-col items-center justify-center gap-2 p-6 text-xs">
         <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1">
           {previewUrl ? (
@@ -59,11 +60,15 @@ export default function GalleryUploadFileSelector({
           <p>{fileSize ?? "최대 5MB 업로드 가능"}</p>
         </div>
       </div>
+
+      {/* 파일 선택 버튼 */}
       <div className="flex w-full">
         <Button composition="textOnly" className="w-full" onClick={handleButtonClick}>
           파일 선택
         </Button>
       </div>
+
+      {/* 실제 파일 입력 */}
       <input
         id={inputId}
         ref={inputRef}

--- a/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
+++ b/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
@@ -43,7 +43,7 @@ export default function GalleryUploadFileSelector({
   return (
     <div className="space-y-3">
       {/* 이미지 프리뷰 카드 */}
-      <div className="bevel-pressed bg-text-invert text-muted flex flex-col items-center justify-center gap-2 p-6 text-xs">
+      <div className="bevel-pressed bg-text-invert text-muted flex flex-col items-center justify-center gap-2 p-4">
         <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1">
           {previewUrl ? (
             <img

--- a/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
+++ b/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
@@ -1,0 +1,77 @@
+import { useId, useRef } from "react";
+
+import Button from "@/components/common/Button/Button";
+
+const ImagePlaceholder = () => (
+  <div className="flex h-full w-full items-center justify-center">
+    <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="Mdi4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+      />
+    </svg>
+  </div>
+);
+
+interface GalleryUploadFileSelectorProps {
+  fileName: string | null;
+  fileSize: string | null;
+  previewUrl: string | null;
+  onFileChange: (file: File | undefined) => void;
+}
+
+export default function GalleryUploadFileSelector({
+  fileName,
+  fileSize,
+  previewUrl,
+  onFileChange,
+}: GalleryUploadFileSelectorProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    onFileChange(file);
+  };
+
+  const handleButtonClick = () => {
+    inputRef.current?.click();
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="bevel-pressed bg-text-invert text-muted flex flex-col items-center justify-center gap-2 p-6 text-xs">
+        <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1">
+          {previewUrl ? (
+            <img
+              src={previewUrl}
+              alt={fileName ?? "업로드 미리보기"}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <ImagePlaceholder />
+          )}
+        </div>
+        <div className="text-center">
+          <p>{fileName ?? "선택된 파일이 없습니다."}</p>
+          <p>{fileSize ?? "최대 5MB 업로드 가능"}</p>
+        </div>
+      </div>
+      <div className="flex w-full">
+        <Button composition="textOnly" className="w-full" onClick={handleButtonClick}>
+          파일 선택
+        </Button>
+      </div>
+      <input
+        id={inputId}
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -31,7 +31,7 @@ export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUpload
   };
 
   return (
-    <div className="h/full w/full flex flex-col gap-3 p-6 text-xs">
+    <div className="flex h-full w-full flex-col gap-3">
       {/* 파일 선택 영역 */}
       <span>파일 선택</span>
       <GalleryUploadFileSelector

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -31,7 +31,8 @@ export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUpload
   };
 
   return (
-    <div className="flex h-full w-full flex-col gap-3 p-6 text-xs">
+    <div className="h/full w/full flex flex-col gap-3 p-6 text-xs">
+      {/* 파일 선택 영역 */}
       <span>파일 선택</span>
       <GalleryUploadFileSelector
         fileName={fileName}
@@ -56,17 +57,19 @@ export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUpload
         }}
       />
 
+      {/* 설명 입력 영역 */}
       <section className="space-y-2">
         <span>설명</span>
         <TextArea
           id={descriptionId}
           className="h-20"
-          placeholder="친구들에게 보여줄 사진 설명을 작성해 보세요."
+          placeholder="사진 설명을 작성해 보세요."
           value={description}
           onChange={(event) => setDescription(event.target.value)}
         />
       </section>
 
+      {/* 업로드/취소 버튼 영역 */}
       <div className="mt-auto flex justify-end gap-2">
         <Button composition="textOnly" onClick={onCancel}>
           취소

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useId, useState } from "react";
+
+import Button from "@/components/common/Button/Button";
+import TextArea from "@/components/common/TextArea/TextArea";
+
+import GalleryUploadFileSelector from "./GalleryUploadFileSelector";
+
+interface GalleryUploadPanelProps {
+  onCancel: () => void;
+  onUpload?: (file?: File, description?: string) => void;
+}
+
+export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUploadPanelProps) {
+  const descriptionId = useId();
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [fileSize, setFileSize] = useState<string | null>(null);
+  const [file, setFile] = useState<File | undefined>(undefined);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [description, setDescription] = useState("");
+  useEffect(
+    () => () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    },
+    [previewUrl]
+  );
+  const handleUpload = () => {
+    onUpload?.(file, description);
+    onCancel();
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col gap-3 p-6 text-xs">
+      <span>파일 선택</span>
+      <GalleryUploadFileSelector
+        fileName={fileName}
+        fileSize={fileSize}
+        previewUrl={previewUrl}
+        onFileChange={(selectedFile) => {
+          if (!selectedFile) {
+            setFileName(null);
+            setFileSize(null);
+            setFile(undefined);
+            setPreviewUrl(null);
+            return;
+          }
+          setFile(selectedFile);
+          setFileName(selectedFile.name);
+          const sizeInMb = selectedFile.size / 1024 / 1024;
+          setFileSize(
+            sizeInMb < 1 ? `${(sizeInMb * 1024).toFixed(0)} KB` : `${sizeInMb.toFixed(1)} MB`
+          );
+          const objectUrl = URL.createObjectURL(selectedFile);
+          setPreviewUrl(objectUrl);
+        }}
+      />
+
+      <section className="space-y-2">
+        <span>설명</span>
+        <TextArea
+          id={descriptionId}
+          className="h-20"
+          placeholder="친구들에게 보여줄 사진 설명을 작성해 보세요."
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+        />
+      </section>
+
+      <div className="mt-auto flex justify-end gap-2">
+        <Button composition="textOnly" onClick={onCancel}>
+          취소
+        </Button>
+        <Button composition="textOnly" onClick={handleUpload} disabled={!file}>
+          업로드
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,8 +1,6 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { Activity, useEffect, useState } from "react";
 
-import Gallery from "@/components/minihome/gallery/Gallery";
-import GalleryUploadPanel from "@/components/minihome/gallery/GalleryUploadPanel";
 import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
@@ -50,11 +48,14 @@ export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHome
         <Activity>홈</Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.gallery}>
-        {galleryDetail.selectedId === "upload" ? (
-          <GalleryUploadPanel onCancel={galleryDetail.exitDetail} />
-        ) : (
-          <Gallery onUpload={() => galleryDetail.enterDetail("upload")} />
-        )}
+        <Activity>
+          갤러리
+          {/* {galleryDetail.selectedId ? (
+            <GalleryDetail photoId={galleryDetail.selectedId} onBack={galleryDetail.exitDetail} />
+          ) : (
+            <GalleryList onSelectPhoto={galleryDetail.enterDetail} />
+          )} */}
+        </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.memo}>
         <Activity>

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,6 +1,7 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { Activity, useEffect, useState } from "react";
 
+import Gallery from "@/components/minihome/gallery/Gallery";
 import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
@@ -48,14 +49,7 @@ export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHome
         <Activity>홈</Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.gallery}>
-        <Activity>
-          갤러리
-          {/* {galleryDetail.selectedId ? (
-            <GalleryDetail photoId={galleryDetail.selectedId} onBack={galleryDetail.exitDetail} />
-          ) : (
-            <GalleryList onSelectPhoto={galleryDetail.enterDetail} />
-          )} */}
-        </Activity>
+        <Gallery />
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.memo}>
         <Activity>

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -2,6 +2,7 @@ import * as Tabs from "@radix-ui/react-tabs";
 import { Activity, useEffect, useState } from "react";
 
 import Gallery from "@/components/minihome/gallery/Gallery";
+import GalleryUploadPanel from "@/components/minihome/gallery/GalleryUploadPanel";
 import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
@@ -49,7 +50,11 @@ export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHome
         <Activity>홈</Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.gallery}>
-        <Gallery />
+        {galleryDetail.selectedId === "upload" ? (
+          <GalleryUploadPanel onCancel={galleryDetail.exitDetail} />
+        ) : (
+          <Gallery onUpload={() => galleryDetail.enterDetail("upload")} />
+        )}
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.memo}>
         <Activity>

--- a/src/pages/minihome/MiniHome.tsx
+++ b/src/pages/minihome/MiniHome.tsx
@@ -1,6 +1,7 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { Activity, useEffect, useState } from "react";
 
+import Gallery from "@/components/minihome/gallery/Gallery";
 import GuestBook from "@/components/minihome/guestbook/GuestBook";
 import RoundedTab from "@/components/os/Tab/RoundedTab";
 import { MINIHOME_TABS, type MiniHomeTabs } from "@/types/minihome.types";
@@ -47,14 +48,9 @@ export default function MiniHome({ ownerId, tab = MINIHOME_TABS.home }: MiniHome
       <Tabs.Content value={MINIHOME_TABS.home}>
         <Activity>홈</Activity>
       </Tabs.Content>
-      <Tabs.Content value={MINIHOME_TABS.gallery}>
+      <Tabs.Content value={MINIHOME_TABS.gallery} className="min-h-0 flex-1">
         <Activity>
-          갤러리
-          {/* {galleryDetail.selectedId ? (
-            <GalleryDetail photoId={galleryDetail.selectedId} onBack={galleryDetail.exitDetail} />
-          ) : (
-            <GalleryList onSelectPhoto={galleryDetail.enterDetail} />
-          )} */}
+          <Gallery ownerId={ownerId} />
         </Activity>
       </Tabs.Content>
       <Tabs.Content value={MINIHOME_TABS.memo}>

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -6,6 +6,23 @@ export interface Database {
   __InternalSupabase: {
     PostgrestVersion: "13.0.5";
   };
+  graphql_public: {
+    Tables: Record<never, never>;
+    Views: Record<never, never>;
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: Record<never, never>;
+    CompositeTypes: Record<never, never>;
+  };
   public: {
     Tables: {
       friend_requests: {
@@ -665,6 +682,9 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       visibility: ["public", "friend", "private"],


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 미니홈 갤러리 탭 내부에서 목록/상세/업로드 뷰 전환을 처리하도록 구조를 정리했습니다.
- 업로드/상세 패널이 창 안에서 자연스럽게 노출되도록 스크롤과 버튼 영역 레이아웃을 보완했습니다.
## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #77 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `Gallery.tsx`: `ownerId` 기반 권한 체크, 내부 `view` 상태(list/detail/upload) 추가, 리스트뷰가 `bevel-pressed` 영역 안에 머무르도록 스크롤 레이아웃 조정
- [x] `GalleryDetailPanel.tsx`: 스크롤 중에도 컨테이너 안에서만 렌더되도록 overflow 구조 보완
- [x] `GalleryUploadPanel.tsx`: 입력 영역을 스크롤 컨테이너로 감싸고 `[취소]/[업로드]` 버튼을 하단 고정, 버튼이 가려지지 않도록 레이아웃 수정
- [x] `GalleryUploadFileSelector.tsx`:위 패널과 맞물리는 스타일 정리


## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

<img width="756" height="660" alt="image" src="https://github.com/user-attachments/assets/f7a0b4dc-8037-4eae-9104-39202d3701ca" />
<img width="767" height="634" alt="image" src="https://github.com/user-attachments/assets/c3c0786f-010c-4ddd-8201-20a2a213dd00" />
<img width="739" height="627" alt="image" src="https://github.com/user-attachments/assets/2ef26111-27e9-463c-baca-4a0b529c1ce8" />
<img width="745" height="623" alt="image" src="https://github.com/user-attachments/assets/1e7ef9ba-4b27-46b0-b4d3-e720b52b1e8b" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
Gallery.tsx에서는 베벨 효과가 스크롤에 가려져서, 베벨을 보호하는 테두리 래퍼를 하나 더 감싸서 구현했습니다
```
    // 베벨 테두리 래퍼
    <div className="bevel-pressed h-full w-full overflow-hidden p-1">
      {/* 내부 컨텐츠 */}
      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
```
