### PR TITLE
[#94] feat(guestbook): 방명록 및 댓글 작성 기능 구현

### DIFF
--- a/src/components/minihome/guestbook/CommentWriteBox.tsx
+++ b/src/components/minihome/guestbook/CommentWriteBox.tsx
@@ -1,11 +1,25 @@
+import { useState } from "react";
+
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
 
-export default function CommentWriteBox() {
+interface CommentWriteBoxProps {
+  entryId: string;
+  onSubmit: (id: string, content: string) => void;
+}
+
+export default function CommentWriteBox({ entryId, onSubmit }: CommentWriteBoxProps) {
+  const [content, setContent] = useState("");
+
   return (
     <div className="flex w-full items-stretch gap-1">
-      <Input className="min-w-0 flex-1" aria-label="답글 내용" />
-      <Button size="md" className="self-center">
+      <Input
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="min-w-0 flex-1"
+        aria-label="답글 내용"
+      />
+      <Button onClick={() => onSubmit(entryId, content)} size="md" className="self-center">
         작성
       </Button>
     </div>

--- a/src/components/minihome/guestbook/CommentWriteBox.tsx
+++ b/src/components/minihome/guestbook/CommentWriteBox.tsx
@@ -19,7 +19,14 @@ export default function CommentWriteBox({ entryId, onSubmit }: CommentWriteBoxPr
         className="min-w-0 flex-1"
         aria-label="답글 내용"
       />
-      <Button onClick={() => onSubmit(entryId, content)} size="md" className="self-center">
+      <Button
+        onClick={() => {
+          onSubmit(entryId, content);
+          setContent("");
+        }}
+        size="md"
+        className="self-center"
+      >
         작성
       </Button>
     </div>

--- a/src/components/minihome/guestbook/GuestBook.tsx
+++ b/src/components/minihome/guestbook/GuestBook.tsx
@@ -6,6 +6,7 @@ import {
   deleteGuestBookEntry,
   deleteGuestBookReply,
   getGuestBookWithComment,
+  insertReply,
 } from "./api/guestbook";
 import CommentWriteBox from "./CommentWriteBox";
 import GuestBookEntry from "./GuestBookEntry";
@@ -49,7 +50,7 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
 
     // TODO: 에러 핸들링 추가
     if (fetchError) {
-      console.error("error");
+      console.error(fetchError);
       setError(true);
       return;
     }
@@ -62,7 +63,7 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
 
     // TODO: 에러 핸들링 추가
     if (fetchError) {
-      console.error("error");
+      console.error(fetchError);
       setError(true);
       return;
     }
@@ -73,6 +74,31 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
           ? {
               ...entry,
               comments: entry.comments.filter((c) => c.id !== replyId),
+            }
+          : entry
+      )
+    );
+  };
+
+  const handleReplyWrite = async (entryId: string, content: string) => {
+    if (content.trim() === "") return;
+    if (!user?.id) return;
+
+    const { data: fetchData, error: fetchError } = await insertReply(user?.id, entryId, content);
+
+    // TODO: 에러 핸들링
+    if (fetchError || !fetchData) {
+      console.error(fetchError);
+      setError(true);
+      return;
+    }
+
+    setData((prev) =>
+      prev.map((entry) =>
+        entry.id === entryId
+          ? {
+              ...entry,
+              comments: fetchData,
             }
           : entry
       )
@@ -106,7 +132,7 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
                       onDelete={() => handleReplyDelete(entry.id, entry.comments[0].id)}
                     />
                   ) : (
-                    isMine && <CommentWriteBox />
+                    isMine && <CommentWriteBox entryId={entry.id} onSubmit={handleReplyWrite} />
                   )}
                 </GuestBookEntry>
               </li>

--- a/src/components/minihome/guestbook/GuestBook.tsx
+++ b/src/components/minihome/guestbook/GuestBook.tsx
@@ -6,6 +6,7 @@ import {
   deleteGuestBookEntry,
   deleteGuestBookReply,
   getGuestBookWithComment,
+  insertEntry,
   insertReply,
 } from "./api/guestbook";
 import CommentWriteBox from "./CommentWriteBox";
@@ -84,7 +85,7 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
     if (content.trim() === "") return;
     if (!user?.id) return;
 
-    const { data: fetchData, error: fetchError } = await insertReply(user?.id, entryId, content);
+    const { data: fetchData, error: fetchError } = await insertReply(user.id, entryId, content);
 
     // TODO: 에러 핸들링
     if (fetchError || !fetchData) {
@@ -105,9 +106,25 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
     );
   };
 
+  const handleEntryWrite = async (content: string) => {
+    if (content.trim() === "") return;
+    if (!user?.id || !ownerId) return;
+
+    const { data: fetchData, error: fetchError } = await insertEntry(user.id, ownerId, content);
+
+    // TODO: 에러 핸들링
+    if (fetchError || !fetchData) {
+      console.error(fetchError);
+      setError(true);
+      return;
+    }
+
+    setData((prev) => [fetchData, ...prev]);
+  };
+
   return (
     <div className="flex h-full min-h-0 flex-col p-4">
-      {!isMine && <GuestbookWriteBox />}
+      {!isMine && <GuestbookWriteBox onSubmit={handleEntryWrite} />}
       <div className="flex min-h-0 flex-1 flex-col gap-1">
         <span className="p">전체 방명록 {data.length}</span>
         <div className="bevel-pressed bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3">

--- a/src/components/minihome/guestbook/GuestbookWriteBox.tsx
+++ b/src/components/minihome/guestbook/GuestbookWriteBox.tsx
@@ -1,14 +1,26 @@
 import { Send } from "lucide-react";
+import { useState } from "react";
 
 import Button from "@/components/common/Button/Button";
 import TextArea from "@/components/common/TextArea/TextArea";
 
-export default function GuestbookWriteBox() {
+export default function GuestbookWriteBox({ onSubmit }: { onSubmit: (content: string) => void }) {
+  const [content, setContent] = useState("");
   return (
     <div className="bevel-pressed mb-3 flex flex-col justify-end gap-1 p-3">
       <span>방명록 남기기</span>
-      <TextArea className="w-full" aria-label="방명록 내용" />
-      <Button>
+      <TextArea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="w-full"
+        aria-label="방명록 내용"
+      />
+      <Button
+        onClick={() => {
+          onSubmit(content);
+          setContent("");
+        }}
+      >
         <Send size="1em" />
         등록
       </Button>

--- a/src/components/minihome/guestbook/api/guestbook.ts
+++ b/src/components/minihome/guestbook/api/guestbook.ts
@@ -2,11 +2,11 @@ import type { PostgrestError } from "@supabase/supabase-js";
 
 import supabase from "@/utils/supabase";
 
-import type { GuestbookWithComments } from "../types/guestbook.types";
+import type { GuestbookCommentWithAuthor, GuestbookWithComments } from "../types/guestbook.types";
 
 export const getGuestBookWithComment = async (
   ownerId: string
-): Promise<{ data: GuestbookWithComments[]; error: unknown }> => {
+): Promise<{ data: GuestbookWithComments[]; error: PostgrestError | null }> => {
   const { data, error } = await supabase
     .from("guestbook_posts")
     .select(
@@ -58,4 +58,26 @@ export const deleteGuestBookReply = async (id: string): Promise<PostgrestError |
   if (error) return error;
 
   return null;
+};
+
+export const insertReply = async (
+  id: string,
+  entryId: string,
+  content: string
+): Promise<{ data: GuestbookCommentWithAuthor[] | null; error: PostgrestError | null }> => {
+  const { data, error } = await supabase
+    .from("guestbook_comments")
+    .insert({ post_id: entryId, author_id: id, content })
+    .select(
+      `
+      id,
+      created_at,
+      content,
+      commenter:profiles!guestbook_comments_author_id_fkey (
+        nickname
+      )
+    `
+    );
+
+  return { data, error };
 };

--- a/src/components/minihome/guestbook/api/guestbook.ts
+++ b/src/components/minihome/guestbook/api/guestbook.ts
@@ -81,3 +81,56 @@ export const insertReply = async (
 
   return { data, error };
 };
+
+export const insertEntry = async (
+  userId: string,
+  ownerId: string,
+  content: string
+): Promise<{ data: GuestbookWithComments | null; error: PostgrestError | null }> => {
+  const { data: homepageData, error: homepageError } = await supabase
+    .from("homepages")
+    .select("id")
+    .eq("owner_id", ownerId)
+    .single();
+
+  if (homepageError || !homepageData) {
+    return { data: null, error: homepageError };
+  }
+
+  const { data, error } = await supabase
+    .from("guestbook_posts")
+    .insert({
+      author_id: userId,
+      homepage_id: homepageData.id,
+      content,
+    })
+    .select(
+      `
+      id,
+      created_at,
+      content,
+
+      homepage:homepages!inner (
+        owner_id
+      ),
+
+      author:profiles!guestbook_posts_author_id_fkey (
+        auth_id,
+        nickname
+      ),
+
+      comments:guestbook_comments!guestbook_comments_post_id_fkey (
+        id,
+        created_at,
+        content,
+
+        commenter:profiles!guestbook_comments_author_id_fkey (
+          nickname
+        )
+      )
+    `
+    )
+    .single();
+
+  return { data, error };
+};

--- a/src/pages/friends/api/searchFriends.ts
+++ b/src/pages/friends/api/searchFriends.ts
@@ -1,7 +1,7 @@
 import supabase from "@/utils/supabase";
 
 export async function searchFriends(keyword: string, userId: string | undefined) {
-  if (!userId) return;
+  if (!userId) return [];
 
   const { data, error } = await supabase
     .from("profiles")


### PR DESCRIPTION
## 📖 개요

방명록 및 댓글 작성 기능 구현

## ✅ 관련 이슈

- Close #94 

## 🛠️ 상세 작업 내용

- [x] 방명록 엔트리에 댓글을 작성할 수 있는 기능 추가
- [x] CommentWriteBox에 entryId 및 onSubmit props 전달하도록 수정
- [x] insertReply API 구현 및 GuestBook에 댓글 작성 로직 구현
- [x] searchFriends에서 userId가 undefined일 때 빈 배열 반환하도록 수정
- [x] 새로운 방명록 엔트리 작성 기능 구현
- [x] insertEntry API 추가 및 GuestBook 컴포넌트에 엔트리 생성 로직 연동
- [x] GuestbookWriteBox를 제어 컴포넌트로 수정하고 onSubmit 콜백 지원 추가

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_
