### PR TITLE
[#96] feat(gallery): 이미지 조회 및 이미지 등록 구현

### DIFF
--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 
-import Button from "@/components/common/Button/Button";
 import { useAuthStore } from "@/stores/useAuthStore";
 
 import { getGalleryImagesByHomepage, getHomepageIdByOwner } from "./api/gallery";
 import GalleryDetailPanel from "./GalleryDetailPanel";
+import GalleryList from "./GalleryList";
 import GalleryUploadPanel from "./GalleryUploadPanel";
 import type { GalleryImage } from "./types/gallery.types";
 
@@ -28,6 +28,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
     ? (images.find((image) => image.id === selectedImageId) ?? null)
     : null;
 
+  // 갤러리 데이터를 ownerId 변경마다 다시 가져온다.
   useEffect(() => {
     if (!ownerId) {
       setImages([]);
@@ -47,6 +48,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
         }
       };
 
+      // 중간 단계에서 실패했을 때 공통으로 실행되는 처리
       const failWithMessage = (message: string) => {
         if (isMounted) {
           setImages([]);
@@ -91,6 +93,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
     };
   }, [ownerId]);
 
+  // 다른 ownerId로 이동하거나 탭을 다시 열었을 때 상세/업로드 상태 초기화
   useEffect(() => {
     setView("list");
     setSelectedImageId(null);
@@ -111,66 +114,24 @@ export default function Gallery({ ownerId }: GalleryProps) {
     setSelectedImageId(null);
   };
 
-  const renderGrid = () => (
-    <div className="mt-2 grid grid-cols-4 gap-1">
-      {images.map((image) => (
-        <button
-          key={image.id}
-          type="button"
-          className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
-          onClick={() => handleSelectImage(image.id)}
-        >
-          <div className="h-full w-full">
-            <img
-              src={image.image_url ?? ""}
-              alt={image.caption ?? "갤러리 이미지"}
-              className="h-full w-full object-cover"
-            />
-          </div>
-        </button>
-      ))}
-    </div>
-  );
-
-  const renderStatusText = (text: string, textClassName = "text-muted") => (
-    <p className={`${textClassName} mt-8 text-center text-sm`}>{text}</p>
-  );
-
-  const renderListBody = () => {
-    if (!ownerId) {
-      return renderStatusText("홈페이지 정보를 찾을 수 없습니다.");
-    }
-    if (isLoading) {
-      return renderStatusText("사진을 불러오는 중입니다...");
-    }
-    if (error) {
-      return renderStatusText(error, "text-red-500");
-    }
-    if (images.length === 0) {
-      return renderStatusText("등록된 사진이 없습니다.");
-    }
-
-    return renderGrid();
-  };
-
-  const renderListView = () => (
-    <div className="bevel-pressed h-full w-full overflow-hidden p-1">
-      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
-        <div className="flex items-center justify-between">
-          <h1>사진첩</h1>
-          {canManageGallery && (
-            <Button composition="textOnly" onClick={handleRequestUpload}>
-              업로드
-            </Button>
-          )}
-        </div>
-
-        {renderListBody()}
-      </div>
-    </div>
-  );
-
   const renderContent = () => {
+    if (view === "list") {
+      return (
+        <GalleryList
+          images={images}
+          isMine={canManageGallery}
+          onRequestUpload={handleRequestUpload}
+          onSelectImage={handleSelectImage}
+          showStatus={{
+            ownerMissing: !ownerId,
+            isLoading,
+            error,
+            isEmpty: images.length === 0,
+          }}
+        />
+      );
+    }
+
     if (view === "detail" && selectedImage) {
       return <GalleryDetailPanel image={selectedImage} onBack={handleBackToList} />;
     }
@@ -179,7 +140,8 @@ export default function Gallery({ ownerId }: GalleryProps) {
       return <GalleryUploadPanel onCancel={handleBackToList} />;
     }
 
-    return renderListView();
+    // 3가지 뷰 상태 모두 해당되지 않는다면 null 반환
+    return null;
   };
 
   return (

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,10 +1,12 @@
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import Button from "@/components/common/Button/Button";
 import { useAuthStore } from "@/stores/useAuthStore";
+import supabase from "@/utils/supabase";
 
 import GalleryDetailPanel from "./GalleryDetailPanel";
 import GalleryUploadPanel from "./GalleryUploadPanel";
+import type { GalleryImage } from "./types/gallery.types";
 
 const ImagePlaceholder = () => (
   <div className="flex h-full w-full items-center justify-center">
@@ -27,13 +29,94 @@ type GalleryView = "list" | "detail" | "upload";
 
 export default function Gallery({ ownerId }: GalleryProps) {
   const [view, setView] = useState<GalleryView>("list");
-  const [selectedImageId, setSelectedImageId] = useState<number | null>(null);
+  const [images, setImages] = useState<GalleryImage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+
   const userId = useAuthStore((state) => state.user?.id);
   const canManageGallery = ownerId !== undefined && ownerId === userId;
 
-  const images = useMemo(() => Array.from({ length: 20 }, (_, i) => i + 1), []);
+  const selectedImage = selectedImageId
+    ? (images.find((image) => image.id === selectedImageId) ?? null)
+    : null;
 
-  const handleSelectImage = (imageId: number) => {
+  useEffect(() => {
+    if (!ownerId) {
+      setImages([]);
+      setError(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchGalleryImages = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const { data: homepage, error: homepageError } = await supabase
+          .from("homepages")
+          .select("id")
+          .eq("owner_id", ownerId)
+          .maybeSingle();
+
+        if (homepageError) throw homepageError;
+        if (!homepage) {
+          if (isMounted) {
+            setImages([]);
+          }
+          return;
+        }
+
+        const { data, error: galleryError } = await supabase
+          .from("homepage_gallery_images")
+          .select("id, caption, created_at, image_url, author_id, homepage_id, visibility")
+          .eq("homepage_id", homepage.id)
+          .order("created_at", { ascending: false });
+
+        if (galleryError) throw galleryError;
+
+        if (isMounted) {
+          setImages(
+            (data ?? []).map((image) => ({
+              id: image.id,
+              caption: image.caption,
+              created_at: image.created_at,
+              image_url: image.image_url,
+              author_id: image.author_id,
+              homepage_id: image.homepage_id,
+              visibility: image.visibility,
+            }))
+          );
+        }
+      } catch (fetchError) {
+        if (isMounted) {
+          setImages([]);
+          setError(
+            fetchError instanceof Error ? fetchError.message : "갤러리를 불러오지 못했습니다."
+          );
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchGalleryImages();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [ownerId]);
+
+  useEffect(() => {
+    setView("list");
+    setSelectedImageId(null);
+  }, [ownerId]);
+
+  const handleSelectImage = (imageId: string) => {
     setSelectedImageId(imageId);
     setView("detail");
   };
@@ -48,10 +131,54 @@ export default function Gallery({ ownerId }: GalleryProps) {
     setSelectedImageId(null);
   };
 
+  const renderGrid = () => (
+    <div className="mt-2 grid grid-cols-4 gap-1">
+      {images.map((image) => (
+        <button
+          key={image.id}
+          type="button"
+          className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
+          onClick={() => handleSelectImage(image.id)}
+        >
+          <div className="h-full w-full">
+            {image.image_url ? (
+              <img
+                src={image.image_url}
+                alt={image.caption ?? "갤러리 이미지"}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <ImagePlaceholder />
+            )}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+
+  const renderStatusText = (text: string, textClassName = "text-muted") => (
+    <p className={`${textClassName} mt-8 text-center text-sm`}>{text}</p>
+  );
+
+  const renderListBody = () => {
+    if (!ownerId) {
+      return renderStatusText("홈페이지 정보를 찾을 수 없습니다.");
+    }
+    if (isLoading) {
+      return renderStatusText("사진을 불러오는 중입니다...");
+    }
+    if (error) {
+      return renderStatusText(error, "text-red-500");
+    }
+    if (images.length === 0) {
+      return renderStatusText("등록된 사진이 없습니다.");
+    }
+
+    return renderGrid();
+  };
+
   const renderListView = () => (
-    // 베벨 테두리 래퍼
     <div className="bevel-pressed h-full w-full overflow-hidden p-1">
-      {/* 내부 컨텐츠 */}
       <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
         <div className="flex items-center justify-between">
           <h1>사진첩</h1>
@@ -62,27 +189,14 @@ export default function Gallery({ ownerId }: GalleryProps) {
           )}
         </div>
 
-        <div className="mt-2 grid grid-cols-4 gap-1">
-          {images.map((image) => (
-            <button
-              key={image}
-              type="button"
-              className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
-              onClick={() => handleSelectImage(image)}
-            >
-              <div className="h-full w-full">
-                <ImagePlaceholder />
-              </div>
-            </button>
-          ))}
-        </div>
+        {renderListBody()}
       </div>
     </div>
   );
 
   const renderContent = () => {
-    if (view === "detail" && selectedImageId !== null) {
-      return <GalleryDetailPanel imageId={selectedImageId} onBack={handleBackToList} />;
+    if (view === "detail" && selectedImage) {
+      return <GalleryDetailPanel image={selectedImage} onBack={handleBackToList} />;
     }
 
     if (view === "upload" && canManageGallery) {

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useAuthStore } from "@/stores/useAuthStore";
 
-import { getGalleryImagesByHomepage, getHomepageIdByOwner } from "./api/gallery";
+import {
+  getGalleryImagesByHomepage,
+  getHomepageIdByOwner,
+  uploadGalleryImage,
+} from "./api/gallery";
 import GalleryDetailPanel from "./GalleryDetailPanel";
 import GalleryList from "./GalleryList";
 import GalleryUploadPanel from "./GalleryUploadPanel";
@@ -18,8 +22,10 @@ export default function Gallery({ ownerId }: GalleryProps) {
   const [view, setView] = useState<GalleryView>("list");
   const [images, setImages] = useState<GalleryImage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+  const [homepageId, setHomepageId] = useState<string | null>(null);
 
   const userId = useAuthStore((state) => state.user?.id);
   const canManageGallery = ownerId !== undefined && ownerId === userId;
@@ -29,69 +35,59 @@ export default function Gallery({ ownerId }: GalleryProps) {
     : null;
 
   // 갤러리 데이터를 ownerId 변경마다 다시 가져온다.
-  useEffect(() => {
+  const fetchGalleryImages = useCallback(async () => {
     if (!ownerId) {
       setImages([]);
-      setError(null);
+      setListError(null);
+      setUploadError(null);
+      setHomepageId(null);
       return;
     }
 
-    let isMounted = true;
+    setIsLoading(true);
+    setListError(null);
 
-    const fetchGalleryImages = async () => {
-      setIsLoading(true);
-      setError(null);
+    const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
 
-      const stopLoading = () => {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      };
+    if (homepageError) {
+      setImages([]);
+      setHomepageId(null);
+      setListError(homepageError.message ?? "홈페이지 정보를 불러오지 못했습니다.");
+      setUploadError(null);
+      setIsLoading(false);
+      return;
+    }
 
-      // 중간 단계에서 실패했을 때 공통으로 실행되는 처리
-      const failWithMessage = (message: string) => {
-        if (isMounted) {
-          setImages([]);
-          setError(message);
-        }
-        stopLoading();
-      };
+    if (!homepage) {
+      setImages([]);
+      setHomepageId(null);
+      setListError(null);
+      setUploadError(null);
+      setIsLoading(false);
+      return;
+    }
 
-      const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
+    const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
 
-      if (homepageError) {
-        failWithMessage(homepageError.message ?? "홈페이지 정보를 불러오지 못했습니다.");
-        return;
-      }
+    if (galleryError) {
+      setImages([]);
+      setHomepageId(homepage.id);
+      setListError(galleryError.message ?? "갤러리를 불러오지 못했습니다.");
+      setUploadError(null);
+      setIsLoading(false);
+      return;
+    }
 
-      if (!homepage) {
-        if (isMounted) {
-          setImages([]);
-        }
-        stopLoading();
-        return;
-      }
-
-      const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
-
-      if (galleryError) {
-        failWithMessage(galleryError.message ?? "갤러리를 불러오지 못했습니다.");
-        return;
-      }
-
-      if (isMounted) {
-        setImages(data ?? []);
-      }
-
-      stopLoading();
-    };
-
-    fetchGalleryImages();
-
-    return () => {
-      isMounted = false;
-    };
+    setHomepageId(homepage.id);
+    setImages(data ?? []);
+    setListError(null);
+    setUploadError(null);
+    setIsLoading(false);
   }, [ownerId]);
+
+  useEffect(() => {
+    fetchGalleryImages();
+  }, [fetchGalleryImages]);
 
   // 다른 ownerId로 이동하거나 탭을 다시 열었을 때 상세/업로드 상태 초기화
   useEffect(() => {
@@ -112,6 +108,36 @@ export default function Gallery({ ownerId }: GalleryProps) {
   const handleBackToList = () => {
     setView("list");
     setSelectedImageId(null);
+    setUploadError(null);
+  };
+
+  const handleUploadComplete = async (file?: File, description?: string) => {
+    if (!file) {
+      throw new Error("업로드할 파일을 선택해 주세요.");
+    }
+    if (!homepageId) {
+      throw new Error("홈페이지 정보를 찾을 수 없습니다.");
+    }
+    if (!userId) {
+      throw new Error("로그인이 필요합니다.");
+    }
+
+    const { error } = await uploadGalleryImage({
+      file,
+      caption: description,
+      homepageId,
+      authorId: userId,
+    });
+
+    if (error) {
+      const message = error.message ?? "이미지를 업로드하지 못했습니다.";
+      setUploadError(message);
+      throw new Error(message);
+    }
+
+    setUploadError(null);
+    setView("list");
+    fetchGalleryImages();
   };
 
   const renderContent = () => {
@@ -125,7 +151,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
           showStatus={{
             ownerMissing: !ownerId,
             isLoading,
-            error,
+            error: listError,
             isEmpty: images.length === 0,
           }}
         />
@@ -137,7 +163,13 @@ export default function Gallery({ ownerId }: GalleryProps) {
     }
 
     if (view === "upload" && canManageGallery) {
-      return <GalleryUploadPanel onCancel={handleBackToList} />;
+      return (
+        <GalleryUploadPanel
+          onCancel={handleBackToList}
+          onUpload={handleUploadComplete}
+          errorMessage={uploadError}
+        />
+      );
     }
 
     // 3가지 뷰 상태 모두 해당되지 않는다면 null 반환

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -23,7 +23,6 @@ export default function Gallery({ ownerId }: GalleryProps) {
   const [images, setImages] = useState<GalleryImage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
-  const [uploadError, setUploadError] = useState<string | null>(null);
   const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
   const [homepageId, setHomepageId] = useState<string | null>(null);
 
@@ -40,24 +39,20 @@ export default function Gallery({ ownerId }: GalleryProps) {
     if (!ownerId) {
       setImages([]);
       setListError(null);
-      setUploadError(null);
       setHomepageId(null);
       return;
     }
 
-    // ownerId를 받아 해당 홈피의 갤러리 목록을 불러오는 공통 함수
     const loadGallery = async () => {
       setIsLoading(true);
       setListError(null);
 
-      // 홈피 ID 조회
       const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
 
       if (homepageError) {
         setImages([]);
         setHomepageId(null);
         setListError(homepageError.message ?? "홈페이지 정보를 불러오지 못했습니다.");
-        setUploadError(null);
         setIsLoading(false);
         return;
       }
@@ -66,19 +61,16 @@ export default function Gallery({ ownerId }: GalleryProps) {
         setImages([]);
         setHomepageId(null);
         setListError(null);
-        setUploadError(null);
         setIsLoading(false);
         return;
       }
 
-      // 실제 갤러리 이미지 목록 조회
       const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
 
       if (galleryError) {
         setImages([]);
         setHomepageId(homepage.id);
         setListError(galleryError.message ?? "갤러리를 불러오지 못했습니다.");
-        setUploadError(null);
         setIsLoading(false);
         return;
       }
@@ -86,7 +78,6 @@ export default function Gallery({ ownerId }: GalleryProps) {
       setHomepageId(homepage.id);
       setImages(data ?? []);
       setListError(null);
-      setUploadError(null);
       setIsLoading(false);
     };
 
@@ -112,7 +103,6 @@ export default function Gallery({ ownerId }: GalleryProps) {
   const handleBackToList = () => {
     setView("list");
     setSelectedImageId(null);
-    setUploadError(null);
   };
 
   const handleUploadComplete = async (file?: File, description?: string) => {
@@ -135,11 +125,9 @@ export default function Gallery({ ownerId }: GalleryProps) {
 
     if (error) {
       const message = error.message ?? "이미지를 업로드하지 못했습니다.";
-      setUploadError(message);
       throw new Error(message);
     }
 
-    setUploadError(null);
     setView("list");
     setReloadVersion((prev) => prev + 1);
   };
@@ -167,13 +155,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
     }
 
     if (view === "upload" && canManageGallery) {
-      return (
-        <GalleryUploadPanel
-          onCancel={handleBackToList}
-          onUpload={handleUploadComplete}
-          errorMessage={uploadError}
-        />
-      );
+      return <GalleryUploadPanel onCancel={handleBackToList} onUpload={handleUploadComplete} />;
     }
 
     // 3가지 뷰 상태 모두 해당되지 않는다면 null 반환

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -29,68 +29,69 @@ export default function Gallery({ ownerId }: GalleryProps) {
 
   const userId = useAuthStore((state) => state.user?.id);
   const canManageGallery = ownerId !== undefined && ownerId === userId;
+  const [reloadVersion, setReloadVersion] = useState(0);
 
   const selectedImage = selectedImageId
     ? (images.find((image) => image.id === selectedImageId) ?? null)
     : null;
 
-  // ownerId를 받아 해당 홈피의 갤러리 목록을 불러오는 공통 함수
-  const loadGallery = async (targetOwnerId?: string) => {
-    if (!targetOwnerId) {
-      setImages([]);
-      setListError(null);
-      setUploadError(null);
-      setHomepageId(null);
-      return;
-    }
-
-    setIsLoading(true);
-    setListError(null);
-
-    // 홈피 ID 조회
-    const { data: homepage, error: homepageError } = await getHomepageIdByOwner(targetOwnerId);
-
-    if (homepageError) {
-      setImages([]);
-      setHomepageId(null);
-      setListError(homepageError.message ?? "홈페이지 정보를 불러오지 못했습니다.");
-      setUploadError(null);
-      setIsLoading(false);
-      return;
-    }
-
-    if (!homepage) {
-      setImages([]);
-      setHomepageId(null);
-      setListError(null);
-      setUploadError(null);
-      setIsLoading(false);
-      return;
-    }
-
-    // 실제 갤러리 이미지 목록 조회
-    const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
-
-    if (galleryError) {
-      setImages([]);
-      setHomepageId(homepage.id);
-      setListError(galleryError.message ?? "갤러리를 불러오지 못했습니다.");
-      setUploadError(null);
-      setIsLoading(false);
-      return;
-    }
-
-    setHomepageId(homepage.id);
-    setImages(data ?? []);
-    setListError(null);
-    setUploadError(null);
-    setIsLoading(false);
-  };
-
   // ownerId나 의존한 값이 변할 때마다 목록을 조회
   useEffect(() => {
-    loadGallery(ownerId);
-  }, [ownerId]);
+    if (!ownerId) {
+      setImages([]);
+      setListError(null);
+      setUploadError(null);
+      setHomepageId(null);
+      return;
+    }
+
+    // ownerId를 받아 해당 홈피의 갤러리 목록을 불러오는 공통 함수
+    const loadGallery = async () => {
+      setIsLoading(true);
+      setListError(null);
+
+      // 홈피 ID 조회
+      const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
+
+      if (homepageError) {
+        setImages([]);
+        setHomepageId(null);
+        setListError(homepageError.message ?? "홈페이지 정보를 불러오지 못했습니다.");
+        setUploadError(null);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!homepage) {
+        setImages([]);
+        setHomepageId(null);
+        setListError(null);
+        setUploadError(null);
+        setIsLoading(false);
+        return;
+      }
+
+      // 실제 갤러리 이미지 목록 조회
+      const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
+
+      if (galleryError) {
+        setImages([]);
+        setHomepageId(homepage.id);
+        setListError(galleryError.message ?? "갤러리를 불러오지 못했습니다.");
+        setUploadError(null);
+        setIsLoading(false);
+        return;
+      }
+
+      setHomepageId(homepage.id);
+      setImages(data ?? []);
+      setListError(null);
+      setUploadError(null);
+      setIsLoading(false);
+    };
+
+    loadGallery();
+  }, [ownerId, reloadVersion]);
 
   // 다른 ownerId로 이동하거나 탭을 다시 열었을 때 상세/업로드 상태 초기화
   useEffect(() => {
@@ -140,7 +141,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
 
     setUploadError(null);
     setView("list");
-    await loadGallery(ownerId);
+    setReloadVersion((prev) => prev + 1);
   };
 
   const renderContent = () => {

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -8,19 +8,6 @@ import GalleryDetailPanel from "./GalleryDetailPanel";
 import GalleryUploadPanel from "./GalleryUploadPanel";
 import type { GalleryImage } from "./types/gallery.types";
 
-const ImagePlaceholder = () => (
-  <div className="flex h-full w-full items-center justify-center">
-    <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="Mdi4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-      />
-    </svg>
-  </div>
-);
-
 interface GalleryProps {
   ownerId?: string;
 }
@@ -134,15 +121,11 @@ export default function Gallery({ ownerId }: GalleryProps) {
           onClick={() => handleSelectImage(image.id)}
         >
           <div className="h-full w-full">
-            {image.image_url ? (
-              <img
-                src={image.image_url}
-                alt={image.caption ?? "갤러리 이미지"}
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <ImagePlaceholder />
-            )}
+            <img
+              src={image.image_url ?? ""}
+              alt={image.caption ?? "갤러리 이미지"}
+              className="h-full w-full object-cover"
+            />
           </div>
         </button>
       ))}

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useAuthStore } from "@/stores/useAuthStore";
 
@@ -34,9 +34,9 @@ export default function Gallery({ ownerId }: GalleryProps) {
     ? (images.find((image) => image.id === selectedImageId) ?? null)
     : null;
 
-  // 갤러리 데이터를 ownerId 변경마다 다시 가져온다.
-  const fetchGalleryImages = useCallback(async () => {
-    if (!ownerId) {
+  // ownerId를 받아 해당 홈피의 갤러리 목록을 불러오는 공통 함수
+  const loadGallery = async (targetOwnerId?: string) => {
+    if (!targetOwnerId) {
       setImages([]);
       setListError(null);
       setUploadError(null);
@@ -47,7 +47,8 @@ export default function Gallery({ ownerId }: GalleryProps) {
     setIsLoading(true);
     setListError(null);
 
-    const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
+    // 홈피 ID 조회
+    const { data: homepage, error: homepageError } = await getHomepageIdByOwner(targetOwnerId);
 
     if (homepageError) {
       setImages([]);
@@ -67,6 +68,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
       return;
     }
 
+    // 실제 갤러리 이미지 목록 조회
     const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
 
     if (galleryError) {
@@ -83,11 +85,12 @@ export default function Gallery({ ownerId }: GalleryProps) {
     setListError(null);
     setUploadError(null);
     setIsLoading(false);
-  }, [ownerId]);
+  };
 
+  // ownerId나 의존한 값이 변할 때마다 목록을 조회
   useEffect(() => {
-    fetchGalleryImages();
-  }, [fetchGalleryImages]);
+    loadGallery(ownerId);
+  }, [ownerId]);
 
   // 다른 ownerId로 이동하거나 탭을 다시 열었을 때 상세/업로드 상태 초기화
   useEffect(() => {
@@ -137,7 +140,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
 
     setUploadError(null);
     setView("list");
-    fetchGalleryImages();
+    await loadGallery(ownerId);
   };
 
   const renderContent = () => {

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -90,6 +90,14 @@ export default function Gallery({ ownerId }: GalleryProps) {
     setSelectedImageId(null);
   }, [ownerId]);
 
+  // 상세 보기 중 선택된 이미지가 목록에서 사라지면 자동으로 리스트 화면으로 복귀
+  useEffect(() => {
+    if (view === "detail" && !selectedImage) {
+      setView("list");
+      setSelectedImageId(null);
+    }
+  }, [view, selectedImage]);
+
   const handleSelectImage = (imageId: string) => {
     setSelectedImageId(imageId);
     setView("detail");

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -54,36 +54,47 @@ export default function Gallery({ ownerId }: GalleryProps) {
       setIsLoading(true);
       setError(null);
 
-      try {
-        const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
-
-        if (homepageError) throw homepageError;
-        if (!homepage) {
-          if (isMounted) {
-            setImages([]);
-          }
-          return;
-        }
-
-        const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
-
-        if (galleryError) throw galleryError;
-
-        if (isMounted) {
-          setImages(data ?? []);
-        }
-      } catch (fetchError) {
-        if (isMounted) {
-          setImages([]);
-          setError(
-            fetchError instanceof Error ? fetchError.message : "갤러리를 불러오지 못했습니다."
-          );
-        }
-      } finally {
+      const stopLoading = () => {
         if (isMounted) {
           setIsLoading(false);
         }
+      };
+
+      const failWithMessage = (message: string) => {
+        if (isMounted) {
+          setImages([]);
+          setError(message);
+        }
+        stopLoading();
+      };
+
+      const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
+
+      if (homepageError) {
+        failWithMessage(homepageError.message ?? "홈페이지 정보를 불러오지 못했습니다.");
+        return;
       }
+
+      if (!homepage) {
+        if (isMounted) {
+          setImages([]);
+        }
+        stopLoading();
+        return;
+      }
+
+      const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
+
+      if (galleryError) {
+        failWithMessage(galleryError.message ?? "갤러리를 불러오지 못했습니다.");
+        return;
+      }
+
+      if (isMounted) {
+        setImages(data ?? []);
+      }
+
+      stopLoading();
     };
 
     fetchGalleryImages();

--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 
 import Button from "@/components/common/Button/Button";
 import { useAuthStore } from "@/stores/useAuthStore";
-import supabase from "@/utils/supabase";
 
+import { getGalleryImagesByHomepage, getHomepageIdByOwner } from "./api/gallery";
 import GalleryDetailPanel from "./GalleryDetailPanel";
 import GalleryUploadPanel from "./GalleryUploadPanel";
 import type { GalleryImage } from "./types/gallery.types";
@@ -55,11 +55,7 @@ export default function Gallery({ ownerId }: GalleryProps) {
       setError(null);
 
       try {
-        const { data: homepage, error: homepageError } = await supabase
-          .from("homepages")
-          .select("id")
-          .eq("owner_id", ownerId)
-          .maybeSingle();
+        const { data: homepage, error: homepageError } = await getHomepageIdByOwner(ownerId);
 
         if (homepageError) throw homepageError;
         if (!homepage) {
@@ -69,26 +65,12 @@ export default function Gallery({ ownerId }: GalleryProps) {
           return;
         }
 
-        const { data, error: galleryError } = await supabase
-          .from("homepage_gallery_images")
-          .select("id, caption, created_at, image_url, author_id, homepage_id, visibility")
-          .eq("homepage_id", homepage.id)
-          .order("created_at", { ascending: false });
+        const { data, error: galleryError } = await getGalleryImagesByHomepage(homepage.id);
 
         if (galleryError) throw galleryError;
 
         if (isMounted) {
-          setImages(
-            (data ?? []).map((image) => ({
-              id: image.id,
-              caption: image.caption,
-              created_at: image.created_at,
-              image_url: image.image_url,
-              author_id: image.author_id,
-              homepage_id: image.homepage_id,
-              visibility: image.visibility,
-            }))
-          );
+          setImages(data ?? []);
         }
       } catch (fetchError) {
         if (isMounted) {

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { ChevronLeft, Heart } from "lucide-react";
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
@@ -5,8 +6,10 @@ import { twMerge } from "tailwind-merge";
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
 
+import type { GalleryImage } from "./types/gallery.types";
+
 interface GalleryDetailPanelProps {
-  imageId: number;
+  image: GalleryImage;
   onBack: () => void;
 }
 
@@ -41,13 +44,6 @@ const MOCK_COMMENTS = [
   },
 ];
 
-const MOCK_DESCRIPTIONS = [
-  "친구들이랑 제주도 다녀왔어요~",
-  "전시회에서 찍은 감성 사진이에요.",
-  "퇴근길 하늘이 예뻐서 한 컷!",
-  "주말마다 산책하는 우리 동네 산책로.",
-];
-
 const ImagePlaceholder = () => (
   <div className="bg-surface flex h-full w-full items-center justify-center">
     <svg className="text-muted h-16 w-16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -62,10 +58,8 @@ const ImagePlaceholder = () => (
   </div>
 );
 
-export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPanelProps) {
+export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanelProps) {
   const [photoLiked, setPhotoLiked] = useState(false);
-  const description =
-    MOCK_DESCRIPTIONS[(imageId - 1) % MOCK_DESCRIPTIONS.length] ?? "설명이 없습니다.";
 
   const togglePhotoLike = () => setPhotoLiked((prev) => !prev);
 
@@ -89,13 +83,23 @@ export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPan
           <section className="flex w-full flex-col items-center gap-4">
             <div className="w-full overflow-hidden">
               <div className="aspect-square h-full w-full overflow-hidden">
-                <ImagePlaceholder />
+                {image.image_url ? (
+                  <img
+                    src={image.image_url}
+                    alt={image.caption ?? "갤러리 이미지"}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <ImagePlaceholder />
+                )}
               </div>
             </div>
 
             <div className="border-primary/30 mt-3 w-full border-t pt-3 text-left">
-              <p>{description}</p>
-              <span className="text-muted">2024.11.10 14:30</span>
+              <p>{image.caption ?? "등록된 설명이 없습니다."}</p>
+              <span className="text-muted">
+                {dayjs(image.created_at).format("YYYY.MM.DD HH:mm")}
+              </span>
             </div>
 
             <div className="border-primary/20 flex w-full flex-wrap items-center justify-between pt-3">

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -86,7 +86,7 @@ export default function GalleryDetailPanel({ imageId, onBack }: GalleryDetailPan
       <div className="flex-1 overflow-hidden">
         <div className="scrollbar flex h-full w-full flex-col gap-4 overflow-y-auto p-2">
           {/* 이미지 표시 영역 */}
-          <section className="flex w-full flex-col items-center gap-4 p-4">
+          <section className="flex w-full flex-col items-center gap-4">
             <div className="w-full overflow-hidden">
               <div className="aspect-square h-full w-full overflow-hidden">
                 <ImagePlaceholder />

--- a/src/components/minihome/gallery/GalleryList.tsx
+++ b/src/components/minihome/gallery/GalleryList.tsx
@@ -1,0 +1,90 @@
+import Button from "@/components/common/Button/Button";
+
+import type { GalleryImage } from "./types/gallery.types";
+
+interface GalleryListProps {
+  images: GalleryImage[];
+  isMine: boolean;
+  onRequestUpload: () => void;
+  onSelectImage: (imageId: string) => void;
+  showStatus: {
+    ownerMissing: boolean;
+    isLoading: boolean;
+    error: string | null;
+    isEmpty: boolean;
+  };
+}
+
+// 갤러리 메인 리스트 (그리드 + 상태 메시지 + 업로드 버튼)
+export default function GalleryList({
+  images,
+  isMine,
+  onRequestUpload,
+  onSelectImage,
+  showStatus,
+}: GalleryListProps) {
+  const hasImages = images.length > 0;
+
+  // ownerId/로딩/에러/빈 상태에 맞는 안내 문구
+  const renderStatus = () => {
+    if (showStatus.ownerMissing) {
+      return (
+        <p className="text-muted mt-8 text-center text-sm">홈페이지 정보를 찾을 수 없습니다.</p>
+      );
+    }
+    if (showStatus.isLoading) {
+      return <p className="text-muted mt-8 text-center text-sm">사진을 불러오는 중입니다...</p>;
+    }
+    if (showStatus.error) {
+      return <p className="mt-8 text-center text-sm text-red-500">{showStatus.error}</p>;
+    }
+    if (showStatus.isEmpty) {
+      return <p className="text-muted mt-8 text-center text-sm">등록된 사진이 없습니다.</p>;
+    }
+    return null;
+  };
+
+  return (
+    <div className="bevel-pressed h-full w-full overflow-hidden p-1">
+      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
+        <div className="flex items-center justify-between">
+          <h1>사진첩</h1>
+          {isMine && (
+            <Button composition="textOnly" onClick={onRequestUpload}>
+              업로드
+            </Button>
+          )}
+        </div>
+
+        {hasImages ? (
+          <div className="mt-2 grid grid-cols-4 gap-1">
+            {images.map((image) => (
+              <button
+                key={image.id}
+                type="button"
+                className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
+                onClick={() => onSelectImage(image.id)}
+              >
+                <div className="h-full w-full">
+                  {image.image_url ? (
+                    <img
+                      src={image.image_url}
+                      alt={image.caption ?? "갤러리 이미지"}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="text-muted flex h-full w-full items-center justify-center text-xs">
+                      이미지 호출 실패
+                    </div>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : (
+          renderStatus()
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/minihome/gallery/GalleryList.tsx
+++ b/src/components/minihome/gallery/GalleryList.tsx
@@ -36,9 +36,7 @@ export default function GalleryList({
     if (showStatus.error) {
       return <p className="mt-8 text-center text-sm text-red-500">{showStatus.error}</p>;
     }
-    if (showStatus.isEmpty) {
-      return <p className="text-muted mt-8 text-center text-sm">등록된 사진이 없습니다.</p>;
-    }
+
     return null;
   };
 

--- a/src/components/minihome/gallery/GalleryList.tsx
+++ b/src/components/minihome/gallery/GalleryList.tsx
@@ -32,9 +32,7 @@ export default function GalleryList({
         <p className="text-muted mt-8 text-center text-sm">홈페이지 정보를 찾을 수 없습니다.</p>
       );
     }
-    if (showStatus.isLoading) {
-      return <p className="text-muted mt-8 text-center text-sm">사진을 불러오는 중입니다...</p>;
-    }
+
     if (showStatus.error) {
       return <p className="mt-8 text-center text-sm text-red-500">{showStatus.error}</p>;
     }
@@ -44,19 +42,30 @@ export default function GalleryList({
     return null;
   };
 
+  const statusContent = renderStatus();
+
   return (
+    // 베벨 테두리 래퍼
     <div className="bevel-pressed h-full w-full overflow-hidden p-1">
+      {/* 내부 컨텐츠 */}
       <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
-        <div className="flex items-center justify-between">
+        {/* 헤더 */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h1>사진첩</h1>
-          {isMine && (
-            <Button composition="textOnly" onClick={onRequestUpload}>
-              업로드
-            </Button>
-          )}
+          <div className="flex flex-col items-end gap-1">
+            {isMine && (
+              <Button composition="textOnly" onClick={onRequestUpload}>
+                업로드
+              </Button>
+            )}
+            {statusContent && (
+              <div className="[&>p]:mt-0 [&>p]:text-right [&>p]:text-xs">{statusContent}</div>
+            )}
+          </div>
         </div>
 
         {hasImages ? (
+          /* 이미지 그리드 영역 */
           <div className="mt-2 grid grid-cols-4 gap-1">
             {images.map((image) => (
               <button
@@ -81,9 +90,7 @@ export default function GalleryList({
               </button>
             ))}
           </div>
-        ) : (
-          renderStatus()
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
+++ b/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
@@ -57,7 +57,7 @@ export default function GalleryUploadFileSelector({
         </div>
         <div className="text-center">
           <p>{fileName ?? "선택된 파일이 없습니다."}</p>
-          <p>{fileSize ?? "최대 5MB 업로드 가능"}</p>
+          <p>{fileSize ?? "최대 50MB 업로드 가능"}</p>
         </div>
       </div>
 

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -50,49 +50,54 @@ export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUpload
   };
 
   return (
-    <div className="flex h-full w-full flex-col gap-3">
-      {/* 파일 선택 영역 */}
-      <span>파일 선택 </span>
+    <div className="flex h-full w-full flex-col gap-3 overflow-hidden">
+      <div className="scrollbar flex-1 overflow-y-auto pr-1">
+        <div className="flex flex-col">
+          {/* 파일 선택 영역 */}
+          <span>파일 선택 </span>
 
-      <GalleryUploadFileSelector
-        fileName={fileName}
-        fileSize={fileSize}
-        previewUrl={previewUrl}
-        onFileChange={(selectedFile) => {
-          if (!selectedFile) {
-            setFileName(null);
-            setFileSize(null);
-            setFile(undefined);
-            setPreviewUrl(null);
-            return;
-          }
-          setFile(selectedFile);
-          setFileName(selectedFile.name);
-          const sizeInMb = selectedFile.size / 1024 / 1024;
-          setFileSize(
-            sizeInMb < 1 ? `${(sizeInMb * 1024).toFixed(0)} KB` : `${sizeInMb.toFixed(1)} MB`
-          );
-          const objectUrl = URL.createObjectURL(selectedFile);
-          setPreviewUrl(objectUrl);
-        }}
-      />
+          <GalleryUploadFileSelector
+            fileName={fileName}
+            fileSize={fileSize}
+            previewUrl={previewUrl}
+            onFileChange={(selectedFile) => {
+              if (!selectedFile) {
+                setFileName(null);
+                setFileSize(null);
+                setFile(undefined);
+                setPreviewUrl(null);
+                return;
+              }
+              setFile(selectedFile);
+              setFileName(selectedFile.name);
+              const sizeInMb = selectedFile.size / 1024 / 1024;
+              setFileSize(
+                sizeInMb < 1 ? `${(sizeInMb * 1024).toFixed(0)} KB` : `${sizeInMb.toFixed(1)} MB`
+              );
+              const objectUrl = URL.createObjectURL(selectedFile);
+              setPreviewUrl(objectUrl);
+            }}
+          />
 
-      {/* 설명 입력 영역 */}
-      <section className="space-y-2">
-        <span>설명</span>
-        <TextArea
-          id={descriptionId}
-          className="h-20"
-          placeholder="사진 설명을 작성해 보세요."
-          value={description}
-          onChange={(event) => setDescription(event.target.value)}
-        />
-      </section>
+          {/* 설명 입력 영역 */}
+          <section className="space-y-2">
+            <span>설명</span>
+            <TextArea
+              id={descriptionId}
+              className="h-20"
+              placeholder="사진 설명을 작성해 보세요."
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+            />
+          </section>
+        </div>
+      </div>
 
       {/* 업로드/취소 버튼 영역 */}
-      <div className="mt-auto flex flex-col gap-2">
-        {submitError && <p className="text-sm text-red-500">{submitError}</p>}
+      <div className="flex flex-col gap-2">
         <div className="flex justify-end gap-2">
+          <div>{submitError && <p className="text-red-500">{submitError}</p>}</div>
+
           <Button composition="textOnly" onClick={onCancel} disabled={isSubmitting}>
             취소
           </Button>

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -16,6 +16,7 @@ export default function GalleryUploadPanel({
   onUpload,
   errorMessage,
 }: GalleryUploadPanelProps) {
+  // TextArea와 연결될 고유 id 생성
   const descriptionId = useId();
   const [fileName, setFileName] = useState<string | null>(null);
   const [fileSize, setFileSize] = useState<string | null>(null);
@@ -25,6 +26,7 @@ export default function GalleryUploadPanel({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  // Blob URL을 사용한 미리보기는 컴포넌트 언마운트 시 해제해 메모리 누수를 방지
   useEffect(
     () => () => {
       if (previewUrl) {

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -7,16 +7,24 @@ import GalleryUploadFileSelector from "./GalleryUploadFileSelector";
 
 interface GalleryUploadPanelProps {
   onCancel: () => void;
-  onUpload?: (file?: File, description?: string) => void;
+  onUpload?: (file?: File, description?: string) => Promise<void> | void;
+  errorMessage?: string | null;
 }
 
-export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUploadPanelProps) {
+export default function GalleryUploadPanel({
+  onCancel,
+  onUpload,
+  errorMessage,
+}: GalleryUploadPanelProps) {
   const descriptionId = useId();
   const [fileName, setFileName] = useState<string | null>(null);
   const [fileSize, setFileSize] = useState<string | null>(null);
   const [file, setFile] = useState<File | undefined>(undefined);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [description, setDescription] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   useEffect(
     () => () => {
       if (previewUrl) {
@@ -25,15 +33,30 @@ export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUpload
     },
     [previewUrl]
   );
-  const handleUpload = () => {
-    onUpload?.(file, description);
-    onCancel();
+
+  const handleUpload = async () => {
+    if (!file || isSubmitting) return;
+    setSubmitError(null);
+    setIsSubmitting(true);
+    try {
+      await onUpload?.(file, description);
+    } catch (err) {
+      if (err instanceof Error) {
+        setSubmitError(err.message);
+      } else {
+        setSubmitError("업로드에 실패했습니다.");
+      }
+      return;
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
     <div className="flex h-full w-full flex-col gap-3">
       {/* 파일 선택 영역 */}
-      <span>파일 선택</span>
+      <span>파일 선택 </span>
+
       <GalleryUploadFileSelector
         fileName={fileName}
         fileSize={fileSize}
@@ -71,11 +94,15 @@ export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUpload
 
       {/* 업로드/취소 버튼 영역 */}
       <div className="mt-auto flex justify-end gap-2">
-        <Button composition="textOnly" onClick={onCancel}>
+        {(submitError ?? errorMessage) && (
+          <p className="text-red-500">{submitError ?? errorMessage}</p>
+        )}
+
+        <Button composition="textOnly" onClick={onCancel} disabled={isSubmitting}>
           취소
         </Button>
-        <Button composition="textOnly" onClick={handleUpload} disabled={!file}>
-          업로드
+        <Button composition="textOnly" onClick={handleUpload} disabled={!file || isSubmitting}>
+          {isSubmitting ? "업로드 중..." : "업로드"}
         </Button>
       </div>
     </div>

--- a/src/components/minihome/gallery/GalleryUploadPanel.tsx
+++ b/src/components/minihome/gallery/GalleryUploadPanel.tsx
@@ -8,14 +8,9 @@ import GalleryUploadFileSelector from "./GalleryUploadFileSelector";
 interface GalleryUploadPanelProps {
   onCancel: () => void;
   onUpload?: (file?: File, description?: string) => Promise<void> | void;
-  errorMessage?: string | null;
 }
 
-export default function GalleryUploadPanel({
-  onCancel,
-  onUpload,
-  errorMessage,
-}: GalleryUploadPanelProps) {
+export default function GalleryUploadPanel({ onCancel, onUpload }: GalleryUploadPanelProps) {
   // TextArea와 연결될 고유 id 생성
   const descriptionId = useId();
   const [fileName, setFileName] = useState<string | null>(null);
@@ -95,17 +90,16 @@ export default function GalleryUploadPanel({
       </section>
 
       {/* 업로드/취소 버튼 영역 */}
-      <div className="mt-auto flex justify-end gap-2">
-        {(submitError ?? errorMessage) && (
-          <p className="text-red-500">{submitError ?? errorMessage}</p>
-        )}
-
-        <Button composition="textOnly" onClick={onCancel} disabled={isSubmitting}>
-          취소
-        </Button>
-        <Button composition="textOnly" onClick={handleUpload} disabled={!file || isSubmitting}>
-          {isSubmitting ? "업로드 중..." : "업로드"}
-        </Button>
+      <div className="mt-auto flex flex-col gap-2">
+        {submitError && <p className="text-sm text-red-500">{submitError}</p>}
+        <div className="flex justify-end gap-2">
+          <Button composition="textOnly" onClick={onCancel} disabled={isSubmitting}>
+            취소
+          </Button>
+          <Button composition="textOnly" onClick={handleUpload} disabled={!file || isSubmitting}>
+            {isSubmitting ? "업로드 중..." : "업로드"}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -4,7 +4,15 @@ const FILE_BUCKET = "files";
 
 // Storage에 저장할 때 겹치지 않도록 홈피 ID + UUID 기반 경로를 생성
 const createUniqueFilePath = (homepageId: string, fileName: string) => {
-  const extension = fileName.split(".").pop() ?? "png";
+  const allowedExtensions = ["png", "jpg", "jpeg", "gif", "webp"];
+  let extension = "";
+  const lastDot = fileName.lastIndexOf(".");
+  if (lastDot !== -1 && lastDot < fileName.length - 1) {
+    extension = fileName.slice(lastDot + 1).toLowerCase();
+  }
+  if (!allowedExtensions.includes(extension)) {
+    extension = "png";
+  }
   const unique =
     typeof crypto !== "undefined" && "randomUUID" in crypto
       ? crypto.randomUUID()
@@ -46,6 +54,14 @@ export const uploadGalleryImage = async ({
   authorId,
   caption,
 }: UploadGalleryImageParams) => {
+  const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    return {
+      data: null,
+      error: new Error("JPEG, PNG, GIF, WebP 파일만 업로드 가능합니다."),
+    };
+  }
+
   const filePath = createUniqueFilePath(homepageId, file.name);
 
   const { error: uploadError } = await supabase.storage.from(FILE_BUCKET).upload(filePath, file, {

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -73,7 +73,7 @@ export const uploadGalleryImage = async ({
     .single();
 
   if (error) {
-    return { data: null, error };
+    return { data: [], error };
   }
 
   return { data: data ?? [], error: null };

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -73,8 +73,9 @@ export const uploadGalleryImage = async ({
     .single();
 
   if (error) {
-    return { data: [], error };
+    await supabase.storage.from(FILE_BUCKET).remove([filePath]);
+    return { data: null, error };
   }
 
-  return { data: data ?? [], error: null };
+  return { data, error: null };
 };

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -1,0 +1,34 @@
+import supabase from "@/utils/supabase";
+
+import type { GalleryImage } from "../types/gallery.types";
+
+export const getHomepageIdByOwner = async (ownerId: string) => {
+  const { data, error } = await supabase
+    .from("homepages")
+    .select("id")
+    .eq("owner_id", ownerId)
+    .maybeSingle();
+
+  return { data, error };
+};
+
+export const getGalleryImagesByHomepage = async (homepageId: string) => {
+  const { data, error } = await supabase
+    .from("homepage_gallery_images")
+    .select("id, caption, created_at, image_url, author_id, homepage_id, visibility")
+    .eq("homepage_id", homepageId)
+    .order("created_at", { ascending: false });
+
+  const parsedData: GalleryImage[] =
+    data?.map((image) => ({
+      id: image.id,
+      caption: image.caption,
+      created_at: image.created_at,
+      image_url: image.image_url,
+      author_id: image.author_id,
+      homepage_id: image.homepage_id,
+      visibility: image.visibility,
+    })) ?? [];
+
+  return { data: parsedData, error };
+};

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -1,7 +1,5 @@
 import supabase from "@/utils/supabase";
 
-import type { GalleryImage } from "../types/gallery.types";
-
 const FILE_BUCKET = "files";
 
 // Storage에 저장할 때 겹치지 않도록 홈피 ID + UUID 기반 경로를 생성
@@ -32,18 +30,7 @@ export const getGalleryImagesByHomepage = async (homepageId: string) => {
     .eq("homepage_id", homepageId)
     .order("created_at", { ascending: false });
 
-  const parsedData: GalleryImage[] =
-    data?.map((image) => ({
-      id: image.id,
-      caption: image.caption,
-      created_at: image.created_at,
-      image_url: image.image_url,
-      author_id: image.author_id,
-      homepage_id: image.homepage_id,
-      visibility: image.visibility,
-    })) ?? [];
-
-  return { data: parsedData, error };
+  return { data: data ?? [], error };
 };
 
 interface UploadGalleryImageParams {
@@ -89,15 +76,5 @@ export const uploadGalleryImage = async ({
     return { data: null, error };
   }
 
-  const parsed: GalleryImage = {
-    id: data.id,
-    caption: data.caption,
-    created_at: data.created_at,
-    image_url: data.image_url,
-    author_id: data.author_id,
-    homepage_id: data.homepage_id,
-    visibility: data.visibility,
-  };
-
-  return { data: parsed, error: null };
+  return { data: data ?? [], error: null };
 };

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -2,6 +2,19 @@ import supabase from "@/utils/supabase";
 
 import type { GalleryImage } from "../types/gallery.types";
 
+const FILE_BUCKET = "files";
+
+// Storage에 저장할 때 겹치지 않도록 홈피 ID + UUID 기반 경로를 생성
+const createUniqueFilePath = (homepageId: string, fileName: string) => {
+  const extension = fileName.split(".").pop() ?? "png";
+  const unique =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  return `gallery/${homepageId}/${unique}.${extension}`;
+};
+
 export const getHomepageIdByOwner = async (ownerId: string) => {
   const { data, error } = await supabase
     .from("homepages")
@@ -31,4 +44,60 @@ export const getGalleryImagesByHomepage = async (homepageId: string) => {
     })) ?? [];
 
   return { data: parsedData, error };
+};
+
+interface UploadGalleryImageParams {
+  file: File;
+  homepageId: string;
+  authorId: string;
+  caption?: string;
+}
+
+export const uploadGalleryImage = async ({
+  file,
+  homepageId,
+  authorId,
+  caption,
+}: UploadGalleryImageParams) => {
+  const filePath = createUniqueFilePath(homepageId, file.name);
+
+  const { error: uploadError } = await supabase.storage.from(FILE_BUCKET).upload(filePath, file, {
+    cacheControl: "3600",
+    upsert: false,
+  });
+
+  if (uploadError) {
+    return { data: null, error: uploadError };
+  }
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from(FILE_BUCKET).getPublicUrl(filePath);
+
+  const { data, error } = await supabase
+    .from("homepage_gallery_images")
+    .insert({
+      homepage_id: homepageId,
+      author_id: authorId,
+      caption: caption ?? null,
+      image_url: publicUrl,
+    })
+    .select("id, caption, created_at, image_url, author_id, homepage_id, visibility")
+    .single();
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  const parsed: GalleryImage = {
+    id: data.id,
+    caption: data.caption,
+    created_at: data.created_at,
+    image_url: data.image_url,
+    author_id: data.author_id,
+    homepage_id: data.homepage_id,
+    visibility: data.visibility,
+  };
+
+  return { data: parsed, error: null };
 };

--- a/src/components/minihome/gallery/types/gallery.types.ts
+++ b/src/components/minihome/gallery/types/gallery.types.ts
@@ -1,0 +1,13 @@
+import type { Database } from "@/types/database.types";
+
+type GalleryImageRow = Database["public"]["Tables"]["homepage_gallery_images"]["Row"];
+
+export interface GalleryImage {
+  id: GalleryImageRow["id"];
+  caption: GalleryImageRow["caption"];
+  image_url: GalleryImageRow["image_url"];
+  created_at: GalleryImageRow["created_at"];
+  author_id: GalleryImageRow["author_id"];
+  homepage_id: GalleryImageRow["homepage_id"];
+  visibility: GalleryImageRow["visibility"];
+}


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 미니홈 갤러리 목록, 상세, 업로드 흐름을 분리,  실제 데이터 조회/등록을 Supabase와 연동했습니다.
- 리스트 전용 컴포넌트, API 모듈, 타입 정의를 추가해 구조를 정리했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #96 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 갤러리 리스트 UI를 `GalleryList` 컴포넌트로 분리 (그리드·상태 메시지·업로드 버튼)
- [x] `gallery/api/gallery.ts`에 조회/등록 API 모듈과 유틸 함수 (`files` 버킷 업로드) 추가
- [x] `gallery/types/gallery.types.ts`로 타입 정의 분리
- [x] 갤러리 조회 로직 구현: `ownerId` 기준으로 홈피 ID → 갤러리 이미지 가져오기
- [x] 업로드 구현: Storage 업로드 + DB 등록, 업로드 완료 후 목록 재조회
- [x] 리스트/업로드 에러 상태 분리 및 UI 노출 위치 정리, 업로드 패널의 에러 메시지 표시


## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
