### PR TITLE
[#97] feat(gallery): 댓글 및 좋아요 기능 구현

### DIFF
--- a/src/components/minihome/gallery/Gallery.tsx
+++ b/src/components/minihome/gallery/Gallery.tsx
@@ -159,7 +159,13 @@ export default function Gallery({ ownerId }: GalleryProps) {
     }
 
     if (view === "detail" && selectedImage) {
-      return <GalleryDetailPanel image={selectedImage} onBack={handleBackToList} />;
+      return (
+        <GalleryDetailPanel
+          image={selectedImage}
+          onBack={handleBackToList}
+          isMine={canManageGallery}
+        />
+      );
     }
 
     if (view === "upload" && canManageGallery) {

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { ChevronLeft, Heart, Send } from "lucide-react";
+import { ChevronLeft, Heart, Send, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
@@ -7,12 +7,17 @@ import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
 import { useAuthStore } from "@/stores/useAuthStore";
 
-import { addGalleryImageComment, getGalleryImageComments } from "./api/gallery";
+import {
+  addGalleryImageComment,
+  deleteGalleryImageComment,
+  getGalleryImageComments,
+} from "./api/gallery";
 import type { GalleryComment, GalleryImage } from "./types/gallery.types";
 
 interface GalleryDetailPanelProps {
   image: GalleryImage;
   onBack: () => void;
+  isMine?: boolean;
 }
 
 // JSON 타입의 댓글 내용을 문자열로 변환
@@ -36,7 +41,11 @@ const stringifyCommentContent = (value: unknown): string => {
   }
 };
 
-export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanelProps) {
+export default function GalleryDetailPanel({
+  image,
+  onBack,
+  isMine = false,
+}: GalleryDetailPanelProps) {
   const [photoLiked, setPhotoLiked] = useState(false);
   const [comments, setComments] = useState<GalleryComment[]>([]);
   const [isLoadingComments, setIsLoadingComments] = useState(false);
@@ -115,6 +124,18 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
       setComments((prev) => [...prev, data]);
       setNewComment("");
     }
+  };
+
+  const handleDeleteComment = async (commentId: string) => {
+    if (!isMine) {
+      return;
+    }
+    const error = await deleteGalleryImageComment(commentId);
+    if (error) {
+      setSubmitError(error.message ?? "댓글을 삭제하지 못했습니다.");
+      return;
+    }
+    setComments((prev) => prev.filter((comment) => comment.id !== commentId));
   };
 
   return (
@@ -218,7 +239,19 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
                         <div className="flex-1">
                           <div className="text-muted mb-1 flex items-center justify-between">
                             <span className="text-primary">{nickname}</span>
-                            <span>{dayjs(comment.created_at).format("YYYY.MM.DD HH:mm")}</span>
+                            <div className="flex items-center gap-2">
+                              <span>{dayjs(comment.created_at).format("YYYY.MM.DD HH:mm")}</span>
+                              {isMine && (
+                                <Button
+                                  size="sm"
+                                  composition="iconOnly"
+                                  aria-label="댓글 삭제"
+                                  onClick={() => handleDeleteComment(comment.id)}
+                                >
+                                  <X size={12} />
+                                </Button>
+                              )}
+                            </div>
                           </div>
                           <p>{body || "내용이 없습니다."}</p>
                         </div>

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -152,8 +152,9 @@ export default function GalleryDetailPanel({
     }
   };
 
-  const handleDeleteComment = async (commentId: string) => {
-    if (!isMine) {
+  const handleDeleteComment = async (commentId: string, commentAuthorId?: string | null) => {
+    if (!isMine && commentAuthorId !== userId) {
+      setSubmitError("댓글 삭제 권한이 없습니다.");
       return;
     }
     const error = await deleteGalleryImageComment(commentId);
@@ -302,12 +303,14 @@ export default function GalleryDetailPanel({
                             <span className="text-primary">{nickname}</span>
                             <div className="flex items-center gap-2">
                               <span>{dayjs(comment.created_at).format("YYYY.MM.DD HH:mm")}</span>
-                              {isMine && (
+                              {(isMine || comment.author?.auth_id === userId) && (
                                 <Button
                                   size="sm"
                                   composition="iconOnly"
                                   aria-label="댓글 삭제"
-                                  onClick={() => handleDeleteComment(comment.id)}
+                                  onClick={() =>
+                                    handleDeleteComment(comment.id, comment.author?.auth_id ?? null)
+                                  }
                                 >
                                   <X size={12} />
                                 </Button>

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { ChevronLeft, Heart } from "lucide-react";
+import { ChevronLeft, Heart, Send } from "lucide-react";
 import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
@@ -159,7 +159,7 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
               {!isLoadingComments &&
                 !commentsError &&
                 comments.map((comment) => {
-                  const nickname = comment.author?.nickname ?? "익명";
+                  const nickname = comment.author?.nickname ?? "알 수 없음";
                   const avatar = comment.author?.avatar_url;
                   const fallbackInitial = nickname.charAt(0);
                   const body = stringifyCommentContent(comment.content);
@@ -193,9 +193,12 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
           </section>
         </div>
       </div>
-      <div className="mt-4 flex shrink-0 items-center gap-2 px-4">
+      <div className="mt-4 flex shrink-0 items-center gap-2 px-[6px]">
         <Input placeholder="댓글을 입력하세요..." aria-label="댓글 입력" />
-        <Button composition="textOnly">등록</Button>
+        <Button size="md" composition="iconText">
+          <Send size={12} />
+          등록
+        </Button>
       </div>
     </div>
   );

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -1,65 +1,80 @@
 import dayjs from "dayjs";
 import { ChevronLeft, Heart } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
 
-import type { GalleryImage } from "./types/gallery.types";
+import { getGalleryImageComments } from "./api/gallery";
+import type { GalleryComment, GalleryImage } from "./types/gallery.types";
 
 interface GalleryDetailPanelProps {
   image: GalleryImage;
   onBack: () => void;
 }
 
-const MOCK_COMMENTS = [
-  {
-    id: 1,
-    nickname: "일촌친구1",
-    timeAgo: "1시간 전",
-    caption: "사진 너무 이쁘다!",
-    avatarUrl: "https://picsum.photos/seed/friend1/80",
-  },
-  {
-    id: 2,
-    nickname: "일촌친구2",
-    timeAgo: "2시간 전",
-    caption: "여기 어디예요? 나도 가고싶다 ㅠㅠ",
-    avatarUrl: "https://picsum.photos/seed/friend2/80",
-  },
-  {
-    id: 3,
-    nickname: "일촌친구3",
-    timeAgo: "3시간 전",
-    caption: "날씨 좋은 날들이 최고지~",
-    avatarUrl: "https://picsum.photos/seed/friend3/80",
-  },
-  {
-    id: 4,
-    nickname: "도토리",
-    timeAgo: "4시간 전",
-    caption: "다들 고마워요! 다음에 같이 가요 ㅎㅎ",
-    avatarUrl: "https://picsum.photos/seed/dotori/80",
-  },
-];
-
-const ImagePlaceholder = () => (
-  <div className="bg-surface flex h-full w-full items-center justify-center">
-    <svg className="text-muted h-16 w-16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2z"
-      />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 11l3 3 5-5 3 3" />
-    </svg>
-  </div>
-);
+// JSON 타입의 댓글 내용을 문자열로 변환
+const stringifyCommentContent = (value: unknown): string => {
+  if (value === null || typeof value === "undefined") {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stringifyCommentContent(item)).join(" ");
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+};
 
 export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanelProps) {
   const [photoLiked, setPhotoLiked] = useState(false);
+  const [comments, setComments] = useState<GalleryComment[]>([]);
+  const [isLoadingComments, setIsLoadingComments] = useState(false);
+  const [commentsError, setCommentsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadComments = async () => {
+      if (!image.id) {
+        setComments([]);
+        setCommentsError(null);
+        return;
+      }
+      setIsLoadingComments(true);
+      setCommentsError(null);
+
+      const { data, error } = await getGalleryImageComments(image.id);
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (error) {
+        setComments([]);
+        setCommentsError(error.message ?? "댓글을 불러오지 못했습니다.");
+      } else {
+        setComments(data);
+        setCommentsError(null);
+      }
+      setIsLoadingComments(false);
+    };
+
+    loadComments();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [image.id]);
 
   const togglePhotoLike = () => setPhotoLiked((prev) => !prev);
 
@@ -90,7 +105,9 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
                     className="h-full w-full object-cover"
                   />
                 ) : (
-                  <ImagePlaceholder />
+                  <div className="text-muted flex h-full w-full items-center justify-center text-sm">
+                    이미지를 찾을 수 없습니다.
+                  </div>
                 )}
               </div>
             </div>
@@ -129,27 +146,49 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
           {/* 댓글 영역 */}
           <section className="bevel-pressed bg-text-invert flex w-full flex-col gap-4 p-4">
             <div className="space-y-4">
-              <p>댓글 4개</p>
-              {MOCK_COMMENTS.map((comment) => (
-                <div key={comment.id} className="bevel-default bg-text-invert p-3">
-                  <div className="flex items-start gap-3">
-                    <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
-                      {comment.avatarUrl ? (
-                        <img src={comment.avatarUrl} alt={`${comment.nickname} avatar`} />
-                      ) : (
-                        comment.nickname.charAt(0)
-                      )}
-                    </div>
-                    <div className="flex-1">
-                      <div className="text-muted mb-1 flex items-center justify-between">
-                        <span className="text-primary font-semibold">{comment.nickname}</span>
-                        <span>{comment.timeAgo}</span>
+              <p>댓글 {comments.length}개</p>
+              {isLoadingComments && (
+                <p className="text-muted text-sm">댓글을 불러오는 중이에요...</p>
+              )}
+              {commentsError && !isLoadingComments && (
+                <p className="text-sm text-red-500">{commentsError}</p>
+              )}
+              {!isLoadingComments && !commentsError && comments.length === 0 && (
+                <p className="text-muted text-sm">첫 댓글을 남겨보세요.</p>
+              )}
+              {!isLoadingComments &&
+                !commentsError &&
+                comments.map((comment) => {
+                  const nickname = comment.author?.nickname ?? "익명";
+                  const avatar = comment.author?.avatar_url;
+                  const fallbackInitial = nickname.charAt(0);
+                  const body = stringifyCommentContent(comment.content);
+
+                  return (
+                    <div key={comment.id} className="bevel-default bg-text-invert p-3">
+                      <div className="flex items-start gap-3">
+                        <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
+                          {avatar ? (
+                            <img
+                              src={avatar}
+                              alt={`${nickname} avatar`}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            fallbackInitial
+                          )}
+                        </div>
+                        <div className="flex-1">
+                          <div className="text-muted mb-1 flex items-center justify-between">
+                            <span className="text-primary font-semibold">{nickname}</span>
+                            <span>{dayjs(comment.created_at).format("YYYY.MM.DD HH:mm")}</span>
+                          </div>
+                          <p>{body || "내용이 없습니다."}</p>
+                        </div>
                       </div>
-                      <p>{comment.caption}</p>
                     </div>
-                  </div>
-                </div>
-              ))}
+                  );
+                })}
             </div>
           </section>
         </div>

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -11,6 +11,9 @@ import {
   addGalleryImageComment,
   deleteGalleryImageComment,
   getGalleryImageComments,
+  getGalleryImageLikeSummary,
+  likeGalleryImage,
+  unlikeGalleryImage,
 } from "./api/gallery";
 import type { GalleryComment, GalleryImage } from "./types/gallery.types";
 
@@ -46,7 +49,10 @@ export default function GalleryDetailPanel({
   onBack,
   isMine = false,
 }: GalleryDetailPanelProps) {
-  const [photoLiked, setPhotoLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState(0);
+  const [isLiked, setIsLiked] = useState(false);
+  const [likeError, setLikeError] = useState<string | null>(null);
+  const [isUpdatingLike, setIsUpdatingLike] = useState(false);
   const [comments, setComments] = useState<GalleryComment[]>([]);
   const [isLoadingComments, setIsLoadingComments] = useState(false);
   const [commentsError, setCommentsError] = useState<string | null>(null);
@@ -58,6 +64,27 @@ export default function GalleryDetailPanel({
 
   useEffect(() => {
     let isMounted = true;
+
+    const loadLikes = async () => {
+      const { count, liked, error } = await getGalleryImageLikeSummary(
+        image.id,
+        userId ?? undefined
+      );
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (error) {
+        setLikeError(error.message ?? "좋아요 정보를 불러오지 못했습니다.");
+        setLikeCount(0);
+        setIsLiked(false);
+      } else {
+        setLikeError(null);
+        setLikeCount(count);
+        setIsLiked(liked);
+      }
+    };
 
     const loadComments = async () => {
       if (!image.id) {
@@ -84,14 +111,13 @@ export default function GalleryDetailPanel({
       setIsLoadingComments(false);
     };
 
+    loadLikes();
     loadComments();
 
     return () => {
       isMounted = false;
     };
-  }, [image.id]);
-
-  const togglePhotoLike = () => setPhotoLiked((prev) => !prev);
+  }, [image.id, userId]);
 
   const handleSubmitComment = async () => {
     const trimmed = newComment.trim();
@@ -136,6 +162,41 @@ export default function GalleryDetailPanel({
       return;
     }
     setComments((prev) => prev.filter((comment) => comment.id !== commentId));
+  };
+
+  const handleToggleLike = async () => {
+    if (!userId) {
+      setLikeError("로그인이 필요합니다.");
+      return;
+    }
+    if (isUpdatingLike) {
+      return;
+    }
+
+    setIsUpdatingLike(true);
+    setLikeError(null);
+
+    if (isLiked) {
+      setIsLiked(false);
+      setLikeCount((prev) => Math.max(0, prev - 1));
+      const error = await unlikeGalleryImage(image.id, userId);
+      if (error) {
+        setIsLiked(true);
+        setLikeCount((prev) => prev + 1);
+        setLikeError(error.message ?? "좋아요 취소에 실패했습니다.");
+      }
+    } else {
+      setIsLiked(true);
+      setLikeCount((prev) => prev + 1);
+      const error = await likeGalleryImage(image.id, userId);
+      if (error) {
+        setIsLiked(false);
+        setLikeCount((prev) => Math.max(0, prev - 1));
+        setLikeError(error.message ?? "좋아요에 실패했습니다.");
+      }
+    }
+
+    setIsUpdatingLike(false);
   };
 
   return (
@@ -183,14 +244,14 @@ export default function GalleryDetailPanel({
               <Button
                 size="sm"
                 composition="iconText"
-                onClick={togglePhotoLike}
-                className={twMerge("text-primary px-3", photoLiked && "text-accent")}
+                onClick={handleToggleLike}
+                className={twMerge("text-primary px-3", isLiked && "text-accent")}
               >
                 <Heart
-                  className={twMerge("h-3.5 w-3.5", photoLiked && "text-accent fill-current")}
-                  fill={photoLiked ? "currentColor" : "none"}
+                  className={twMerge("h-3.5 w-3.5", isLiked && "text-accent fill-current")}
+                  fill={isLiked ? "currentColor" : "none"}
                 />
-                좋아요 4
+                좋아요 {likeCount}
               </Button>
               <div className="flex items-center gap-2">
                 <Button size="sm" composition="textOnly" className="text-primary px-3">
@@ -288,6 +349,7 @@ export default function GalleryDetailPanel({
             등록
           </Button>
         </div>
+        {likeError && <p className="text-right text-red-500">{likeError}</p>}
         {submitError && <p className="text-right text-red-500">{submitError}</p>}
       </div>
     </div>

--- a/src/components/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/components/minihome/gallery/GalleryDetailPanel.tsx
@@ -5,8 +5,9 @@ import { twMerge } from "tailwind-merge";
 
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
+import { useAuthStore } from "@/stores/useAuthStore";
 
-import { getGalleryImageComments } from "./api/gallery";
+import { addGalleryImageComment, getGalleryImageComments } from "./api/gallery";
 import type { GalleryComment, GalleryImage } from "./types/gallery.types";
 
 interface GalleryDetailPanelProps {
@@ -40,6 +41,11 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
   const [comments, setComments] = useState<GalleryComment[]>([]);
   const [isLoadingComments, setIsLoadingComments] = useState(false);
   const [commentsError, setCommentsError] = useState<string | null>(null);
+  const [newComment, setNewComment] = useState("");
+  const [isSubmittingComment, setIsSubmittingComment] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const userId = useAuthStore((state) => state.user?.id);
 
   useEffect(() => {
     let isMounted = true;
@@ -78,6 +84,39 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
 
   const togglePhotoLike = () => setPhotoLiked((prev) => !prev);
 
+  const handleSubmitComment = async () => {
+    const trimmed = newComment.trim();
+    if (!userId) {
+      setSubmitError("로그인이 필요합니다.");
+      return;
+    }
+    // 아무것도 안 적혀있으면 댓글 안 남김
+    if (!trimmed) {
+      return;
+    }
+
+    setIsSubmittingComment(true);
+    setSubmitError(null);
+
+    const { data, error } = await addGalleryImageComment({
+      imageId: image.id,
+      authorId: userId,
+      content: trimmed,
+    });
+
+    setIsSubmittingComment(false);
+
+    if (error) {
+      setSubmitError(error.message ?? "댓글을 등록하지 못했습니다.");
+      return;
+    }
+
+    if (data) {
+      setComments((prev) => [...prev, data]);
+      setNewComment("");
+    }
+  };
+
   return (
     // 전체 컨테이너
     <div className="relative flex h-full w-full flex-col overflow-hidden">
@@ -105,7 +144,7 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
                     className="h-full w-full object-cover"
                   />
                 ) : (
-                  <div className="text-muted flex h-full w-full items-center justify-center text-sm">
+                  <div className="text-muted flex h-full w-full items-center justify-center">
                     이미지를 찾을 수 없습니다.
                   </div>
                 )}
@@ -147,14 +186,12 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
           <section className="bevel-pressed bg-text-invert flex w-full flex-col gap-4 p-4">
             <div className="space-y-4">
               <p>댓글 {comments.length}개</p>
-              {isLoadingComments && (
-                <p className="text-muted text-sm">댓글을 불러오는 중이에요...</p>
-              )}
+              {isLoadingComments && <p className="text-muted">댓글을 불러오는 중입니다.</p>}
               {commentsError && !isLoadingComments && (
-                <p className="text-sm text-red-500">{commentsError}</p>
+                <p className="text-red-500">{commentsError}</p>
               )}
               {!isLoadingComments && !commentsError && comments.length === 0 && (
-                <p className="text-muted text-sm">첫 댓글을 남겨보세요.</p>
+                <p className="text-muted">첫 댓글을 남겨보세요.</p>
               )}
               {!isLoadingComments &&
                 !commentsError &&
@@ -180,7 +217,7 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
                         </div>
                         <div className="flex-1">
                           <div className="text-muted mb-1 flex items-center justify-between">
-                            <span className="text-primary font-semibold">{nickname}</span>
+                            <span className="text-primary">{nickname}</span>
                             <span>{dayjs(comment.created_at).format("YYYY.MM.DD HH:mm")}</span>
                           </div>
                           <p>{body || "내용이 없습니다."}</p>
@@ -193,12 +230,32 @@ export default function GalleryDetailPanel({ image, onBack }: GalleryDetailPanel
           </section>
         </div>
       </div>
-      <div className="mt-4 flex shrink-0 items-center gap-2 px-[6px]">
-        <Input placeholder="댓글을 입력하세요..." aria-label="댓글 입력" />
-        <Button size="md" composition="iconText">
-          <Send size={12} />
-          등록
-        </Button>
+      <div className="mt-4 flex shrink-0 flex-col gap-2 px-[6px]">
+        <div className="flex items-center gap-2">
+          <Input
+            placeholder={userId ? "댓글을 입력하세요..." : "로그인이 필요합니다."}
+            aria-label="댓글 입력"
+            value={newComment}
+            onChange={(event) => setNewComment(event.target.value)}
+            disabled={isSubmittingComment || !userId}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                handleSubmitComment();
+              }
+            }}
+          />
+          <Button
+            size="md"
+            composition="iconText"
+            onClick={handleSubmitComment}
+            disabled={!userId || isSubmittingComment}
+          >
+            <Send size={12} />
+            등록
+          </Button>
+        </div>
+        {submitError && <p className="text-right text-red-500">{submitError}</p>}
       </div>
     </div>
   );

--- a/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
+++ b/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
@@ -5,12 +5,14 @@ import Button from "@/components/common/Button/Button";
 interface GalleryUploadFileSelectorProps {
   fileName: string | null;
   fileSize: string | null;
+  previewUrl: string | null;
   onFileChange: (file: File | undefined) => void;
 }
 
 export default function GalleryUploadFileSelector({
   fileName,
   fileSize,
+  previewUrl,
   onFileChange,
 }: GalleryUploadFileSelectorProps) {
   const inputId = useId();
@@ -29,7 +31,15 @@ export default function GalleryUploadFileSelector({
     <div className="space-y-3">
       {/* 이미지 프리뷰 카드 */}
       <div className="bevel-pressed bg-text-invert text-muted flex flex-col items-center justify-center gap-2 p-4">
-        <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1" />
+        <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1">
+          {previewUrl ? (
+            <img
+              src={previewUrl}
+              alt={fileName ?? "미리보기"}
+              className="h-full w-full object-cover"
+            />
+          ) : null}
+        </div>
         <div className="text-center">
           <p>{fileName ?? "선택된 파일이 없습니다."}</p>
           <p>{fileSize ?? "최대 50MB 업로드 가능"}</p>

--- a/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
+++ b/src/components/minihome/gallery/GalleryUploadFileSelector.tsx
@@ -2,30 +2,15 @@ import { useId, useRef } from "react";
 
 import Button from "@/components/common/Button/Button";
 
-const ImagePlaceholder = () => (
-  <div className="flex h-full w-full items-center justify-center">
-    <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="Mdi4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-      />
-    </svg>
-  </div>
-);
-
 interface GalleryUploadFileSelectorProps {
   fileName: string | null;
   fileSize: string | null;
-  previewUrl: string | null;
   onFileChange: (file: File | undefined) => void;
 }
 
 export default function GalleryUploadFileSelector({
   fileName,
   fileSize,
-  previewUrl,
   onFileChange,
 }: GalleryUploadFileSelectorProps) {
   const inputId = useId();
@@ -44,17 +29,7 @@ export default function GalleryUploadFileSelector({
     <div className="space-y-3">
       {/* 이미지 프리뷰 카드 */}
       <div className="bevel-pressed bg-text-invert text-muted flex flex-col items-center justify-center gap-2 p-4">
-        <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1">
-          {previewUrl ? (
-            <img
-              src={previewUrl}
-              alt={fileName ?? "업로드 미리보기"}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <ImagePlaceholder />
-          )}
-        </div>
+        <div className="bevel-default flex h-24 w-24 items-center justify-center overflow-hidden p-1" />
         <div className="text-center">
           <p>{fileName ?? "선택된 파일이 없습니다."}</p>
           <p>{fileSize ?? "최대 50MB 업로드 가능"}</p>

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -172,3 +172,51 @@ export const deleteGalleryImageComment = async (
     .eq("id", commentId);
   return error;
 };
+
+export const getGalleryImageLikeSummary = async (
+  imageId: string,
+  userId?: string
+): Promise<{ count: number; liked: boolean; error: PostgrestError | null }> => {
+  const { count, error } = await supabase
+    .from("homepage_gallery_image_likes")
+    .select("*", { count: "exact", head: true })
+    .eq("image_id", imageId);
+
+  if (error) {
+    return { count: 0, liked: false, error };
+  }
+
+  if (!userId) {
+    return { count: count ?? 0, liked: false, error: null };
+  }
+
+  const { data: likeRow, error: likedError } = await supabase
+    .from("homepage_gallery_image_likes")
+    .select("id")
+    .eq("image_id", imageId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (likedError && likedError.code !== "PGRST116") {
+    return { count: count ?? 0, liked: false, error: likedError };
+  }
+
+  return { count: count ?? 0, liked: Boolean(likeRow), error: null };
+};
+
+export const likeGalleryImage = async (imageId: string, userId: string) => {
+  const { error } = await supabase.from("homepage_gallery_image_likes").insert({
+    image_id: imageId,
+    user_id: userId,
+  });
+  return error;
+};
+
+export const unlikeGalleryImage = async (imageId: string, userId: string) => {
+  const { error } = await supabase
+    .from("homepage_gallery_image_likes")
+    .delete()
+    .eq("image_id", imageId)
+    .eq("user_id", userId);
+  return error;
+};

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -177,31 +177,23 @@ export const getGalleryImageLikeSummary = async (
   imageId: string,
   userId?: string
 ): Promise<{ count: number; liked: boolean; error: PostgrestError | null }> => {
-  const { count, error } = await supabase
+  const query = supabase
     .from("homepage_gallery_image_likes")
-    .select("*", { count: "exact", head: true })
+    .select("user_id", { count: "exact" })
     .eq("image_id", imageId);
+
+  const { data, count, error } = await (userId ? query.eq("user_id", userId) : query);
 
   if (error) {
     return { count: 0, liked: false, error };
   }
 
-  if (!userId) {
-    return { count: count ?? 0, liked: false, error: null };
+  if (userId) {
+    return { count: count ?? 0, liked: (data?.length ?? 0) > 0, error: null };
   }
 
-  const { data: likeRow, error: likedError } = await supabase
-    .from("homepage_gallery_image_likes")
-    .select("id")
-    .eq("image_id", imageId)
-    .eq("user_id", userId)
-    .maybeSingle();
-
-  if (likedError && likedError.code !== "PGRST116") {
-    return { count: count ?? 0, liked: false, error: likedError };
-  }
-
-  return { count: count ?? 0, liked: Boolean(likeRow), error: null };
+  const likeCount = count ?? 0;
+  return { count: likeCount, liked: false, error: null };
 };
 
 export const likeGalleryImage = async (imageId: string, userId: string) => {

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -123,3 +123,42 @@ export const getGalleryImageComments = async (
 
   return { data: (data as GalleryComment[] | null) ?? [], error };
 };
+
+interface AddGalleryImageCommentParams {
+  imageId: string;
+  authorId: string;
+  content: string;
+}
+
+export const addGalleryImageComment = async ({
+  imageId,
+  authorId,
+  content,
+}: AddGalleryImageCommentParams): Promise<{
+  data: GalleryComment | null;
+  error: PostgrestError | null;
+}> => {
+  const { data, error } = await supabase
+    .from("homepage_gallery_image_comments")
+    .insert({
+      post_id: imageId,
+      author_id: authorId,
+      content,
+    })
+    .select(
+      `
+      id,
+      created_at,
+      content,
+      author_id,
+      author:profiles!homepage_gallery_image_relies_author_id_fkey (
+        auth_id,
+        nickname,
+        avatar_url
+      )
+    `
+    )
+    .single();
+
+  return { data: (data as GalleryComment | null) ?? null, error };
+};

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -1,4 +1,8 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
 import supabase from "@/utils/supabase";
+
+import type { GalleryComment } from "../types/gallery.types";
 
 const FILE_BUCKET = "files";
 
@@ -94,4 +98,28 @@ export const uploadGalleryImage = async ({
   }
 
   return { data, error: null };
+};
+
+export const getGalleryImageComments = async (
+  imageId: string
+): Promise<{ data: GalleryComment[]; error: PostgrestError | null }> => {
+  const { data, error } = await supabase
+    .from("homepage_gallery_image_comments")
+    .select(
+      `
+      id,
+      created_at,
+      content,
+      author_id,
+      author:profiles!homepage_gallery_image_relies_author_id_fkey (
+        auth_id,
+        nickname,
+        avatar_url
+      )
+    `
+    )
+    .eq("post_id", imageId)
+    .order("created_at", { ascending: true });
+
+  return { data: (data as GalleryComment[] | null) ?? [], error };
 };

--- a/src/components/minihome/gallery/api/gallery.ts
+++ b/src/components/minihome/gallery/api/gallery.ts
@@ -162,3 +162,13 @@ export const addGalleryImageComment = async ({
 
   return { data: (data as GalleryComment | null) ?? null, error };
 };
+
+export const deleteGalleryImageComment = async (
+  commentId: string
+): Promise<PostgrestError | null> => {
+  const { error } = await supabase
+    .from("homepage_gallery_image_comments")
+    .delete()
+    .eq("id", commentId);
+  return error;
+};

--- a/src/components/minihome/gallery/types/gallery.types.ts
+++ b/src/components/minihome/gallery/types/gallery.types.ts
@@ -1,6 +1,8 @@
 import type { Database } from "@/types/database.types";
 
 type GalleryImageRow = Database["public"]["Tables"]["homepage_gallery_images"]["Row"];
+type GalleryCommentRow = Database["public"]["Tables"]["homepage_gallery_image_comments"]["Row"];
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
 
 export interface GalleryImage {
   id: GalleryImageRow["id"];
@@ -10,4 +12,16 @@ export interface GalleryImage {
   author_id: GalleryImageRow["author_id"];
   homepage_id: GalleryImageRow["homepage_id"];
   visibility: GalleryImageRow["visibility"];
+}
+
+export interface GalleryComment {
+  id: GalleryCommentRow["id"];
+  created_at: GalleryCommentRow["created_at"];
+  content: GalleryCommentRow["content"];
+  author_id: GalleryCommentRow["author_id"];
+  author: {
+    auth_id: ProfileRow["auth_id"];
+    nickname: ProfileRow["nickname"] | null;
+    avatar_url: ProfileRow["avatar_url"] | null;
+  } | null;
 }


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
갤러리 상세 화면에서 댓글 CRUD와 좋아요 토글 기능을 구현했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #97 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->
- [x] 댓글 목록 조회/등록/삭제
- [x] 내 홈피 일 경우 모든 댓글 삭제 가능
- [x] 다른 사람 홈피일 경우 내 댓글만 삭제 가능  
- [x] 좋아요 수 및 나의 좋아요 여부조회
- [x] 좋아요 토글(추가/삭제) 및 낙관적 UI 반영


## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="720" height="392" alt="image" src="https://github.com/user-attachments/assets/6e7b060d-ab37-4ffd-84ae-77ae17f8da41" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
