### PR TITLE
[#105] feat(window): 드래그 가능한 윈도우 및 카테고리 기반 위치 저장 기능 추가

### DIFF
--- a/src/components/os/Taskbar/Taskbar.tsx
+++ b/src/components/os/Taskbar/Taskbar.tsx
@@ -62,7 +62,7 @@ export default function Taskbar({ className, config = "default", ...rest }: Task
   };
 
   return (
-    <nav className={twMerge(taskbar, className)} {...rest}>
+    <nav className={twMerge(taskbar, "z-50", className)} {...rest}>
       {showStart && <StartMenu />}
       <ul className="flex flex-1 items-center gap-1 overflow-hidden">
         {Object.values(windows).map((window) => {

--- a/src/components/window/Window/Window.tsx
+++ b/src/components/window/Window/Window.tsx
@@ -1,16 +1,23 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import type { RefObject } from "react";
+import { useEffect, useState, type RefObject } from "react";
 import { twMerge } from "tailwind-merge";
 
-import TitleBar, { type TitleBarProps } from "../TitleBar/TitleBar";
+import TitleBar, { type TitleBarProps } from "@/components/window/TitleBar/TitleBar";
+import { useDraggable } from "@/hooks/useDraggable";
+import { useWindowStore } from "@/stores/useWindowStore";
+import type { WindowAppId } from "@/types/window.types";
 
 interface WindowProps extends Dialog.DialogProps, TitleBarProps {
   ref: RefObject<HTMLElement | null>;
+  windowId: WindowAppId;
   description?: string | undefined;
   isActive?: boolean;
 }
 
+type Position = { x: number; y: number } | null;
+
 export default function Window({
+  windowId,
   open,
   buttons,
   onClose,
@@ -22,7 +29,34 @@ export default function Window({
   isActive,
   className,
 }: WindowProps) {
-  // const { onMouseDown } = useDraggable();
+  const { windows, categoryPositions, updateWindowPosition } = useWindowStore();
+  const category = windows[windowId]?.category;
+  const savedPosition = category ? categoryPositions[category] : undefined;
+  const [position, setPosition] = useState<Position>(savedPosition ?? null);
+  const { onMouseDown, onDrag, isDragging } = useDraggable();
+
+  useEffect(() => {
+    if (!isDragging && position) {
+      updateWindowPosition(windowId, position);
+    }
+  }, [isDragging, position, windowId, updateWindowPosition]);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    let frameId: number;
+
+    const update = () => {
+      const next = onDrag.current;
+      if (next) {
+        setPosition((prev) => (prev?.x === next.x && prev.y === next.y ? prev : next));
+      }
+      frameId = requestAnimationFrame(update);
+    };
+
+    frameId = requestAnimationFrame(update);
+    return () => cancelAnimationFrame(frameId);
+  }, [isDragging, onDrag]);
 
   return (
     <Dialog.Root defaultOpen open={open} modal={false}>
@@ -33,11 +67,21 @@ export default function Window({
               "bevel-default absolute inset-0 inline-flex h-full w-full flex-1 flex-col p-[3px] focus:outline-none",
               // TODO: 가변 사이즈 변경
               "md:h-[500px] md:w-[600px]",
-              // TODO: 드래그 시 변경
-              "md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2",
+
+              position === null &&
+                "md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2",
+
               isActive ? "z-40" : "z-10",
+
               className
             )}
+            style={
+              position
+                ? {
+                    transform: `translate(${position.x}px, ${position.y}px)`,
+                  }
+                : undefined
+            }
           >
             <Dialog.Title className="sr-only">{title}</Dialog.Title>
             <Dialog.Description className="sr-only">{description}</Dialog.Description>
@@ -46,7 +90,7 @@ export default function Window({
               title={title}
               buttons={buttons}
               onClose={onClose}
-              // onMouseDown={(event) => onMouseDown(event)}
+              onMouseDown={(event) => onMouseDown(event)}
             />
             {children}
           </section>

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useDraggable = () => {
+  const [isDragging, setIsDragging] = useState(false);
+  const offset = useRef({ x: 0, y: 0 });
+  const onDrag = useRef({ x: 0, y: 0 });
+
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    const window = event.currentTarget.parentElement;
+    const rect = window?.getBoundingClientRect();
+
+    if (!rect) return;
+
+    setIsDragging(true);
+
+    offset.current = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+
+    onDrag.current = {
+      x: rect.left,
+      y: rect.top,
+    };
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!isDragging) return;
+
+      onDrag.current = {
+        x: event.clientX - offset.current.x,
+        y: event.clientY - offset.current.y,
+      };
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging]);
+
+  return {
+    onMouseDown: handleMouseDown,
+    isDragging,
+    onDrag,
+  };
+};

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -83,6 +83,7 @@ export default function OsMain() {
               icon={app.icon}
               isActive={isActive}
               onPointerDown={() => setActiveWindow(windowState.id)}
+              windowId={windowState.id}
             >
               <Component windowId={windowState.id} ownerId={windowState.ownerId} />
             </Window>

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -5,13 +5,20 @@ import { immer } from "zustand/middleware/immer";
 import { WINDOW_INFO } from "@/config/windowInfo";
 import type { WindowAppId, WindowCategory, WindowInstance } from "@/types/window.types";
 
+interface Position {
+  x: number;
+  y: number;
+}
+
 interface WindowStore {
   windows: Partial<Record<WindowAppId, WindowInstance>>;
   activeWindowId: WindowAppId | null;
+  categoryPositions: Partial<Record<WindowCategory, Position>>;
   openWindow: (id: WindowAppId, ownerId?: string) => void;
   closeWindow: (id: WindowAppId) => void;
   setActiveWindow: (id: WindowAppId) => void;
   updateWindowTitle: (id: WindowAppId, title: string) => void;
+  updateWindowPosition: (id: WindowAppId, position: Position) => void;
 }
 
 const clearWindowsByCategory = (
@@ -23,7 +30,9 @@ const clearWindowsByCategory = (
     .map((window) => window.id);
 
   idsToDelete.forEach((id) => {
-    if (id) delete windows[id];
+    if (id) {
+      delete windows[id];
+    }
   });
 };
 
@@ -32,6 +41,8 @@ export const useWindowStore = create<WindowStore>()(
     immer((set) => ({
       windows: {},
       activeWindowId: null,
+      windowPositions: {},
+      categoryPositions: {},
 
       openWindow: (id, ownerId) =>
         set((state) => {
@@ -74,6 +85,15 @@ export const useWindowStore = create<WindowStore>()(
         set((state) => {
           if (state.windows[id]) {
             state.windows[id].caption = title;
+          }
+        }),
+
+      updateWindowPosition: (id, position) =>
+        set((state) => {
+          const instance = state.windows[id];
+
+          if (instance) {
+            state.categoryPositions[instance.category] = position;
           }
         }),
     })),

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "dev": true,
+      "*": false
+    }
+  }
+}


### PR DESCRIPTION
## 📖 개요

드래그 가능한 윈도우 및 카테고리 기반 위치 저장 기능 추가

## ✅ 관련 이슈

- Close #105 

## 🛠️ 상세 작업 내용

- [x] useDraggable 훅을 도입해 윈도우 드래그 기능 구현
- [x] 윈도우 위치를 카테고리 단위로 저장, 복원하도록 스토어 구조 개선
- [x] Window 및 OsMain 컴포넌트에 드래그 동작 및 위치 관리 로직 통합
- [x] 브랜치별 배포 제한을 위한 vercel.json 구성 추가

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_
