### PR TITLE
fix(type): friends 검색 페이지에서 Profile 타입 import 오류 수정 및 윈도우 로직 리팩토링

### DIFF
--- a/src/components/window/Window/Window.tsx
+++ b/src/components/window/Window/Window.tsx
@@ -36,10 +36,10 @@ export default function Window({
   const { onMouseDown, onDrag, isDragging } = useDraggable();
 
   useEffect(() => {
-    if (!isDragging && position) {
-      updateWindowPosition(windowId, position);
+    if (!isDragging && position && category) {
+      updateWindowPosition(category, position);
     }
-  }, [isDragging, position, windowId, updateWindowPosition]);
+  }, [isDragging, position, category, updateWindowPosition]);
 
   useEffect(() => {
     if (!isDragging) return;

--- a/src/pages/friends/Search.tsx
+++ b/src/pages/friends/Search.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input/Input";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useWindowStore } from "@/stores/useWindowStore";
-import type { Profile } from "@/types/profile";
+import type { Profile } from "@/types/profile.types";
 
 import { searchFriends } from "./api/searchFriends";
 

--- a/src/stores/useWindowStore.ts
+++ b/src/stores/useWindowStore.ts
@@ -18,7 +18,7 @@ interface WindowStore {
   closeWindow: (id: WindowAppId) => void;
   setActiveWindow: (id: WindowAppId) => void;
   updateWindowTitle: (id: WindowAppId, title: string) => void;
-  updateWindowPosition: (id: WindowAppId, position: Position) => void;
+  updateWindowPosition: (category: WindowCategory, position: Position) => void;
 }
 
 const clearWindowsByCategory = (
@@ -41,7 +41,6 @@ export const useWindowStore = create<WindowStore>()(
     immer((set) => ({
       windows: {},
       activeWindowId: null,
-      windowPositions: {},
       categoryPositions: {},
 
       openWindow: (id, ownerId) =>
@@ -88,13 +87,9 @@ export const useWindowStore = create<WindowStore>()(
           }
         }),
 
-      updateWindowPosition: (id, position) =>
+      updateWindowPosition: (category, position) =>
         set((state) => {
-          const instance = state.windows[id];
-
-          if (instance) {
-            state.categoryPositions[instance.category] = position;
-          }
+          state.categoryPositions[category] = position;
         }),
     })),
     { name: "WindowStore" }


### PR DESCRIPTION
## 📖 개요

friends 검색 페이지에서 Profile 타입 import 오류 수정 및 윈도우 로직 수정

## ✅ 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- [x] friends 검색 페이지에서 Profile 타입 import 오류 수정
- [x] 불필요한 윈도우 id 관련 로직 삭제

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_