### PR TITLE
[#119] feat(friends): 친구 목록 구현

### DIFF
--- a/src/pages/friends/Friends.tsx
+++ b/src/pages/friends/Friends.tsx
@@ -2,6 +2,7 @@ import * as Tabs from "@radix-ui/react-tabs";
 import { useEffect, useState } from "react";
 
 import RoundedTab from "@/components/os/Tab/RoundedTab";
+import List from "@/pages/friends/list/List";
 import Request from "@/pages/friends/request/Request";
 import Search from "@/pages/friends/search/Search";
 import { FRIENDS_TABS, type FriendsTabs } from "@/pages/friends/types/friends.types";
@@ -41,7 +42,7 @@ export default function Friends({ windowId, tab = FRIENDS_TABS.search }: Friends
         <Request />
       </Tabs.Content>
       <Tabs.Content value={FRIENDS_TABS.list} asChild>
-        <Search />
+        <List />
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/src/pages/friends/api/friends.ts
+++ b/src/pages/friends/api/friends.ts
@@ -1,6 +1,6 @@
 import type { PostgrestError } from "@supabase/supabase-js";
 
-import type { FriendRequest } from "@/pages/friends/types/friends.types";
+import type { FriendRelation, FriendRequest } from "@/pages/friends/types/friends.types";
 import supabase from "@/utils/supabase";
 
 export const searchProfiles = async (keyword: string, userId: string | undefined) => {
@@ -107,6 +107,37 @@ export const rejectFriendRequest = async (requestId: string, userId: string) => 
     id: requestId,
     addressee_id: userId,
   });
+
+  if (error) throw error;
+};
+
+export const getFriends = async (
+  userId: string
+): Promise<{ data: FriendRelation[] | null; error: PostgrestError | null }> => {
+  const { data, error } = await supabase
+    .from("friends")
+    .select(
+      `
+      *,
+      user1_profile:profiles!friends_user1_id_fkey(*),
+      user2_profile:profiles!friends_user2_id_fkey(*)
+    `
+    )
+    .or(`user1_id.eq.${userId},user2_id.eq.${userId}`)
+    .order("created_at", { ascending: false });
+
+  return {
+    data: (data as FriendRelation[] | null) ?? null,
+    error,
+  };
+};
+
+export const removeFriend = async (friendshipId: string) => {
+  if (!friendshipId) {
+    throw new Error("친구 정보를 찾을 수 없습니다.");
+  }
+
+  const { error } = await supabase.from("friends").delete().eq("id", friendshipId);
 
   if (error) throw error;
 };

--- a/src/pages/friends/list/List.tsx
+++ b/src/pages/friends/list/List.tsx
@@ -1,3 +1,101 @@
+import { Home, UserMinus2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import Button from "@/components/common/Button/Button";
+import { getFriends, removeFriend } from "@/pages/friends/api/friends";
+import type { FriendRelation } from "@/pages/friends/types/friends.types";
+import { useAuthStore } from "@/stores/useAuthStore";
+import { useWindowStore } from "@/stores/useWindowStore";
+
 export default function List() {
-  return <h1>List Component</h1>;
+  const user = useAuthStore((state) => state.user);
+  const openWindow = useWindowStore((state) => state.openWindow);
+
+  const [friends, setFriends] = useState<FriendRelation[]>([]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetch = async () => {
+      const { data, error } = await getFriends(user.id);
+
+      // TODO: 에러 핸들링
+      if (error) {
+        console.error(error);
+        return;
+      }
+
+      setFriends(data ?? []);
+    };
+
+    fetch();
+  }, [user]);
+
+  const handleVisitMiniHome = (ownerId: string) => {
+    openWindow("friendHome", ownerId);
+  };
+
+  const handleRemoveFriend = async (relationId: string) => {
+    try {
+      await removeFriend(relationId);
+      setFriends((prev) => prev.filter((friend) => friend.id !== relationId));
+    } catch (error) {
+      // TODO: 에러 핸들링
+      console.error(error);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-1 p-4">
+      <span className="pl-1">친구 목록 {friends.length}</span>
+      <div className="bevel-pressed flex min-h-0 flex-1 flex-col overflow-hidden px-[3px]">
+        <div className="bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3 pr-0">
+          <ul className="flex flex-col gap-2">
+            {friends.map((friend) => {
+              const profile =
+                friend.user1_id === user?.id ? friend.user2_profile : friend.user1_profile;
+
+              if (!profile) return null;
+
+              return (
+                <li key={friend.id}>
+                  <div className="flex items-center gap-3 p-2 pl-2 select-none">
+                    <div className="shrink-0">
+                      <img
+                        src={profile.avatar_url ?? ""}
+                        alt="프로필 아바타"
+                        className="h-8 w-8 rounded-full object-cover"
+                      />
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate text-sm font-medium">{profile.nickname}</span>
+                      <span className="text-text-subtle truncate text-xs">{profile.email}</span>
+                    </div>
+                    <div className="flex shrink-0 gap-2">
+                      <Button
+                        size="md"
+                        composition="iconText"
+                        onClick={() => handleVisitMiniHome(profile.auth_id)}
+                      >
+                        <Home className="h-4 w-4" />
+                        미니홈 방문
+                      </Button>
+                      <Button
+                        size="md"
+                        composition="iconText"
+                        onClick={() => handleRemoveFriend(friend.id)}
+                      >
+                        <UserMinus2 className="h-4 w-4" />
+                        친구 끊기
+                      </Button>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/friends/types/friends.types.ts
+++ b/src/pages/friends/types/friends.types.ts
@@ -16,3 +16,10 @@ export type FriendRequestRow = Database["public"]["Tables"]["friend_requests"]["
 export type FriendRequest = FriendRequestRow & {
   requester: Profile;
 };
+
+export type FriendRow = Database["public"]["Tables"]["friends"]["Row"];
+
+export type FriendRelation = FriendRow & {
+  user1_profile: Profile | null;
+  user2_profile: Profile | null;
+};


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
친구 목록 탭을 구현하고, 미니홈 방문/친구 삭제 기능을 구현하였습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #119 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] getFriends, removeFriend API를 추가해 친구 관계 + 프로필 조인을 한 번에 가져오도록 구현
- [x] FriendRelation 타입을 정의해 조인 결과(user1/user2 프로필)를 안전하게 다루도록 설정
- [x] List 컴포넌트에서 친구 목록 로딩, 미니홈 방문, 친구 끊기 버튼 UI 및 상태 업데이트 흐름을 구현
- [x] Friends 탭 구성에 친구 목록 탭을 연결하여 Search/Request/List 3개 탭을 완성

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="755" height="631" alt="image" src="https://github.com/user-attachments/assets/61adc9fc-2566-432b-a26f-fa6854e572f4" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
