### PR TITLE
[#127] fix(os): OS 레이아웃 개선 및 오버 스크롤 방지 기능 추가

### DIFF
--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -20,7 +20,11 @@ export default function AuthLayout() {
           "md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2"
         )}
       >
-        <TitleBar icon={Logo} title="Welcome to BackSpace" />
+        <TitleBar
+          icon={Logo}
+          title="Welcome to BackSpace"
+          className="cursor-default active:cursor-default"
+        />
         <Outlet />
       </section>
     </main>

--- a/src/pages/os/OsMain.tsx
+++ b/src/pages/os/OsMain.tsx
@@ -41,8 +41,8 @@ export default function OsMain() {
   };
 
   return (
-    <main ref={ref} className="bg-base-2 flex h-screen flex-col">
-      <div className="flex-1 p-4">
+    <main className="bg-base-2 flex h-dvh max-h-dvh flex-col overflow-hidden">
+      <section ref={ref} className="relative flex-1 overflow-hidden p-4" aria-label="데스크톱">
         <div
           className="grid h-full w-full auto-cols-max grid-flow-row auto-rows-max gap-6 md:gap-8"
           aria-label="바로가기"
@@ -89,7 +89,7 @@ export default function OsMain() {
             </Window>
           );
         })}
-      </div>
+      </section>
       <Taskbar />
     </main>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -54,6 +54,7 @@ body {
 
 body {
   font-size: 11px;
+  overscroll-behavior: none;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## 📖 개요

OS 레이아웃 개선 및 오버 스크롤 방지 기능 추가

## ✅ 관련 이슈

- Close #127 
- Close #135 

## 🛠️ 상세 작업 내용

- [x] OsMain에 h-dvh, max-h-dvh 적용하여 뷰포트 기반 레이아웃 안정화
- [x] overflow 제어를 위해 OS 영역 구조 개선
- [x] globals.css에 body overscroll-behavior: none 추가하여 불필요한 스크롤 체이닝 방지
- [x] AuthLayout의 TitleBar에 기본 커서 스타일 적용해 UX 개선

## 📸 스크린샷

_N/A_

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

`overscroll-behavior: none` 적용 후 윈도우 내부 스크롤 OS 외 다른 페이지에서 스크롤 체감이나 동작 이상이 없는지 한 번씩 체크 부탁드립니다.
