### PR TITLE
[#138] refactor(container): Bevel 스크롤 컨테이너 분리/적용

### DIFF
--- a/src/components/Container/BevelScrollContainer.tsx
+++ b/src/components/Container/BevelScrollContainer.tsx
@@ -3,9 +3,7 @@ import type { PropsWithChildren } from "react";
 export default function BevelScrollContainer({ children }: PropsWithChildren) {
   return (
     <div className="bevel-pressed h-full w-full overflow-hidden p-1">
-      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
-        {children}
-      </div>
+      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto p-4">{children}</div>
     </div>
   );
 }

--- a/src/components/Container/BevelScrollContainer.tsx
+++ b/src/components/Container/BevelScrollContainer.tsx
@@ -1,9 +1,17 @@
 import type { PropsWithChildren } from "react";
+import { twMerge } from "tailwind-merge";
 
-export default function BevelScrollContainer({ children }: PropsWithChildren) {
+export default function BevelScrollContainer({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
   return (
     <div className="bevel-pressed h-full w-full overflow-hidden p-1">
-      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto p-4">{children}</div>
+      <div
+        className={twMerge("scrollbar bg-text-invert h-full w-full overflow-y-auto p-4", className)}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/Container/BevelScrollContainer.tsx
+++ b/src/components/Container/BevelScrollContainer.tsx
@@ -8,7 +8,7 @@ export default function BevelScrollContainer({
   return (
     <div className="bevel-pressed h-full w-full overflow-hidden p-1">
       <div
-        className={twMerge("scrollbar bg-text-invert h-full w-full overflow-y-auto p-4", className)}
+        className={twMerge("scrollbar bg-text-invert h-full w-full overflow-y-auto p-3", className)}
       >
         {children}
       </div>

--- a/src/components/Container/BevelScrollContainer.tsx
+++ b/src/components/Container/BevelScrollContainer.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from "react";
+
+export default function BevelScrollContainer({ children }: PropsWithChildren) {
+  return (
+    <div className="bevel-pressed h-full w-full overflow-hidden p-1">
+      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/features/friends/list/List.tsx
+++ b/src/features/friends/list/List.tsx
@@ -2,6 +2,7 @@ import { Home, UserMinus2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import Button from "@/components/Button/Button";
+import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useWindowStore } from "@/stores/useWindowStore";
 
@@ -49,8 +50,8 @@ export default function List() {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-1 p-4">
       <span className="pl-1">친구 목록 {friends.length}</span>
-      <div className="bevel-pressed flex min-h-0 flex-1 flex-col overflow-hidden px-[3px]">
-        <div className="bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3 pr-0">
+      <div className="flex min-h-0 flex-1">
+        <BevelScrollContainer>
           <ul className="flex flex-col gap-2">
             {friends.map((friend) => {
               const profile =
@@ -95,7 +96,7 @@ export default function List() {
               );
             })}
           </ul>
-        </div>
+        </BevelScrollContainer>
       </div>
     </div>
   );

--- a/src/features/friends/request/Request.tsx
+++ b/src/features/friends/request/Request.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import Button from "@/components/Button/Button";
+import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import { useAuthStore } from "@/stores/useAuthStore";
 
 import { acceptFriendRequest, getFriendRequests, rejectFriendRequest } from "../api/friends";
@@ -52,8 +53,8 @@ export default function Request() {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-1 p-4">
       <span className="pl-1">친구 신청 {requests.length}</span>
-      <div className="bevel-pressed flex min-h-0 flex-1 flex-col overflow-hidden px-[3px]">
-        <div className="bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3 pr-0">
+      <div className="flex min-h-0 flex-1">
+        <BevelScrollContainer>
           <ul className="flex flex-col gap-2">
             {requests.map((request) => (
               <li key={request.id}>
@@ -86,7 +87,7 @@ export default function Request() {
               </li>
             ))}
           </ul>
-        </div>
+        </BevelScrollContainer>
       </div>
     </div>
   );

--- a/src/features/friends/search/Search.tsx
+++ b/src/features/friends/search/Search.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import Button from "@/components/Button/Button";
+import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import Input from "@/components/Input/Input";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useWindowStore } from "@/stores/useWindowStore";
@@ -68,9 +69,9 @@ export default function Search() {
       {hasSearched && (
         <div className="mt-4 flex min-h-0 flex-1 flex-col gap-1">
           <span className="pl-1">검색 결과 {results.length}</span>
-          <div className="bevel-pressed flex min-h-0 flex-1 overflow-hidden px-[3px]">
-            <div className="bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3 pr-0">
-              <ul>
+          <div className="flex min-h-0 flex-1">
+            <BevelScrollContainer>
+              <ul className="flex flex-col gap-2">
                 {results.map((Profile) => (
                   <li key={Profile.auth_id}>
                     <div className="flex items-center gap-3 p-2 pl-2 select-none">
@@ -100,7 +101,7 @@ export default function Search() {
                   </li>
                 ))}
               </ul>
-            </div>
+            </BevelScrollContainer>
           </div>
         </div>
       )}

--- a/src/features/minihome/gallery/GalleryList.tsx
+++ b/src/features/minihome/gallery/GalleryList.tsx
@@ -1,4 +1,5 @@
 import Button from "@/components/Button/Button";
+import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 
 import type { GalleryImage } from "./types/gallery.types";
 
@@ -43,53 +44,49 @@ export default function GalleryList({
   const statusContent = renderStatus();
 
   return (
-    // 베벨 테두리 래퍼
-    <div className="bevel-pressed h-full w-full overflow-hidden p-1">
-      {/* 내부 컨텐츠 */}
-      <div className="scrollbar bg-text-invert h-full w-full overflow-y-auto px-4 pt-4 pb-4">
-        {/* 헤더 */}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1>사진첩</h1>
-          <div className="flex flex-col items-end gap-1">
-            {isMine && (
-              <Button composition="textOnly" onClick={onRequestUpload}>
-                업로드
-              </Button>
-            )}
-            {statusContent && (
-              <div className="[&>p]:mt-0 [&>p]:text-right [&>p]:text-xs">{statusContent}</div>
-            )}
-          </div>
+    <BevelScrollContainer>
+      {/* 헤더 */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1>사진첩</h1>
+        <div className="flex flex-col items-end gap-1">
+          {isMine && (
+            <Button composition="textOnly" onClick={onRequestUpload}>
+              업로드
+            </Button>
+          )}
+          {statusContent && (
+            <div className="[&>p]:mt-0 [&>p]:text-right [&>p]:text-xs">{statusContent}</div>
+          )}
         </div>
-
-        {hasImages ? (
-          /* 이미지 그리드 영역 */
-          <div className="mt-2 grid grid-cols-4 gap-1">
-            {images.map((image) => (
-              <button
-                key={image.id}
-                type="button"
-                className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
-                onClick={() => onSelectImage(image.id)}
-              >
-                <div className="h-full w-full">
-                  {image.image_url ? (
-                    <img
-                      src={image.image_url}
-                      alt={image.caption ?? "갤러리 이미지"}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <div className="text-muted flex h-full w-full items-center justify-center text-xs">
-                      이미지 호출 실패
-                    </div>
-                  )}
-                </div>
-              </button>
-            ))}
-          </div>
-        ) : null}
       </div>
-    </div>
+
+      {hasImages ? (
+        /* 이미지 그리드 영역 */
+        <div className="mt-2 grid grid-cols-4 gap-1">
+          {images.map((image) => (
+            <button
+              key={image.id}
+              type="button"
+              className="bevel-default aspect-square w-full cursor-pointer overflow-hidden p-1 transition hover:opacity-90"
+              onClick={() => onSelectImage(image.id)}
+            >
+              <div className="h-full w-full">
+                {image.image_url ? (
+                  <img
+                    src={image.image_url}
+                    alt={image.caption ?? "갤러리 이미지"}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <div className="text-muted flex h-full w-full items-center justify-center text-xs">
+                    이미지 호출 실패
+                  </div>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </BevelScrollContainer>
   );
 }

--- a/src/features/minihome/guestbook/GuestBook.tsx
+++ b/src/features/minihome/guestbook/GuestBook.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import { useAuthStore } from "@/stores/useAuthStore";
 
 import {
@@ -126,34 +127,36 @@ export default function GuestBook({ ownerId }: { ownerId: string | undefined }) 
       {!isMine && <EntryTextArea onSubmit={handleEntry} />}
       <div className="flex min-h-0 flex-1 flex-col gap-1">
         <span className="p">전체 방명록 {data.length}</span>
-        <div className="bevel-pressed bg-text-invert scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3">
-          <ul className="flex flex-col gap-2">
-            {data.map((entry) => (
-              <li key={entry.id}>
-                <Entry
-                  id={entry.id}
-                  author={entry.author}
-                  created_at={entry.created_at}
-                  content={entry.content}
-                  canDelete={isMine || entry.author?.auth_id === user?.id}
-                  onDelete={() => handleEntryDelete(entry.id)}
-                >
-                  {entry.comments.length > 0 ? (
-                    <Comment
-                      id={entry.comments[0].id}
-                      commenter={entry.comments[0].commenter}
-                      created_at={entry.comments[0].created_at}
-                      content={entry.comments[0].content}
-                      canDelete={isMine}
-                      onDelete={() => handleReplyDelete(entry.id, entry.comments[0].id)}
-                    />
-                  ) : (
-                    isMine && <CommentInput entryId={entry.id} onSubmit={handleReplyWrite} />
-                  )}
-                </Entry>
-              </li>
-            ))}
-          </ul>
+        <div className="flex min-h-0 flex-1">
+          <BevelScrollContainer>
+            <ul className="flex flex-col gap-2">
+              {data.map((entry) => (
+                <li key={entry.id}>
+                  <Entry
+                    id={entry.id}
+                    author={entry.author}
+                    created_at={entry.created_at}
+                    content={entry.content}
+                    canDelete={isMine || entry.author?.auth_id === user?.id}
+                    onDelete={() => handleEntryDelete(entry.id)}
+                  >
+                    {entry.comments.length > 0 ? (
+                      <Comment
+                        id={entry.comments[0].id}
+                        commenter={entry.comments[0].commenter}
+                        created_at={entry.comments[0].created_at}
+                        content={entry.comments[0].content}
+                        canDelete={isMine}
+                        onDelete={() => handleReplyDelete(entry.id, entry.comments[0].id)}
+                      />
+                    ) : (
+                      isMine && <CommentInput entryId={entry.id} onSubmit={handleReplyWrite} />
+                    )}
+                  </Entry>
+                </li>
+              ))}
+            </ul>
+          </BevelScrollContainer>
         </div>
       </div>
     </div>

--- a/src/features/minihome/post/list/PostList.tsx
+++ b/src/features/minihome/post/list/PostList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import { useAuthUser } from "@/hooks/useAuthUser";
 import type { PostWithCounts } from "@/types/post.types";
 import supabase from "@/utils/supabase";
@@ -69,8 +70,8 @@ export default function PostList({ onPostClick, ownerId }: PostListProps) {
   }
 
   return (
-    <div className="bevel-pressed bg-text-invert flex min-h-0 flex-1 flex-col overflow-hidden py-2.5">
-      <div className="scrollbar flex min-h-0 flex-col gap-2 overflow-y-auto pl-4">
+    <BevelScrollContainer>
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
         {posts.length > 0 ? (
           posts.map((post) => (
             <PostItem
@@ -84,6 +85,6 @@ export default function PostList({ onPostClick, ownerId }: PostListProps) {
           <div className="py-4 text-center opacity-60">작성된 게시글이 없습니다.</div>
         )}
       </div>
-    </div>
+    </BevelScrollContainer>
   );
 }


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 중복되던 베벨+스크롤 래퍼를 `BevelScrollContainer`로 분리하고 갤러리/메모/방명록/친구창 리스트 영역에 공통 적용했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #138 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] `src/components/Container/BevelScrollContainer.tsx` 추가
- [x] 갤러리 리스트·업로드 등 미니홈 컴포넌트에 컨테이너 적용
- [x] 메모 탭(게시글 목록/상세)에 컨테이너 적용
- [x] 방명록 리스트에 컨테이너 적용
- [x] 친구 Search/Request/List 화면에 컨테이너 적용 및 import 정리

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="744" height="625" alt="image" src="https://github.com/user-attachments/assets/b0000321-3e1d-48eb-9a4e-e7ad012f4388" />
<img width="746" height="623" alt="image" src="https://github.com/user-attachments/assets/0ea6bdc2-21a7-4fe3-ab4a-86cf93de6152" />
<img width="751" height="621" alt="image" src="https://github.com/user-attachments/assets/2709e29f-3f7f-403f-9c96-56bda4dc0196" />
<img width="743" height="619" alt="image" src="https://github.com/user-attachments/assets/3e8caa5f-a7ac-4021-979a-33e0a6bee128" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
 공통적으로 갤러리의 스타일인 p-4를 적용했습니다.