### PR TITLE
[#134] feat(avatar): 고스트 아이콘 폴백이 포함된 Avatar 컴포넌트 추가 및 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9987,6 +9987,17 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "name": "rolldown-vite",
       "version": "7.1.14",

--- a/src/assets/icons/ghost.svg
+++ b/src/assets/icons/ghost.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="Entertainment-Events-Hobbies-Horror-Ghost--Streamline-Pixel">
+  <desc>
+    Entertainment Events Hobbies Horror Ghost Streamline Icon: https://streamlinehq.com
+  </desc>
+  <title>entertainment-events-hobbies-horror-ghost</title>
+  <g>
+    <path d="M29.71 19.81h1.53v4.57h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m29.71 0 -1.52 0 0 1.52 -1.53 0 0 1.53 1.53 0 0 1.52 1.52 0 0 -1.52 1.53 0 0 -1.53 -1.53 0 0 -1.52z" fill="currentColor" stroke-width="1"></path>
+    <path d="M28.19 10.67h1.52v9.14h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M26.66 24.38h3.05v1.52h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M26.66 7.62h1.53v3.05h-1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M25.14 25.9h1.52v1.53h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M25.14 21.33h1.52v3.05h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M25.14 6.1h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M23.62 27.43h1.52v1.52h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m25.14 10.67 -1.52 0 0 1.52 -1.53 0 0 1.52 1.53 0 0 1.53 1.52 0 0 -1.53 1.52 0 0 -1.52 -1.52 0 0 -1.52z" fill="currentColor" stroke-width="1"></path>
+    <path d="M22.09 4.57h3.05V6.1h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M20.57 28.95h3.05v1.53h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M17.52 15.24v4.57h4.57v-4.57Zm3.05 3.05h-1.53v-1.53h1.53Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.9 30.48h10.67V32H9.9Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M16 21.33h1.52v3.05H16Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M14.47 3.05h7.62v1.52h-7.62Z" fill="currentColor" stroke-width="1"></path>
+    <path d="m14.47 15.24 1.53 0 0 -1.53 1.52 0 0 -1.52 -1.52 0 0 -1.52 -1.53 0 0 1.52 -1.52 0 0 1.52 1.52 0 0 1.53z" fill="currentColor" stroke-width="1"></path>
+    <path d="M12.95 24.38H16v1.52h-3.05Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M11.43 4.57h3.04V6.1h-3.04Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M11.43 21.33h1.52v3.05h-1.52Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.9 6.1h1.53v1.52H9.9Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M9.9 0h1.53v1.52H9.9Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.85 28.95H9.9v1.53H6.85Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M8.38 7.62H9.9v3.05H8.38Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M6.85 10.67h1.53v9.14H6.85Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M5.33 27.43h1.52v1.52H5.33Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M5.33 4.57h1.52v4.57H5.33Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M3.81 25.9h1.52v1.53H3.81Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M3.81 19.81h3.04v1.52H3.81Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M2.28 3.05h3.05v1.52H2.28Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M2.28 24.38h1.53v1.52H2.28Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M2.28 18.29h1.53v1.52H2.28Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M0.76 9.14h4.57v1.53H0.76Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M2.28 6.1h1.53v1.52H2.28Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M0.76 19.81h1.52v4.57H0.76Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M0.76 13.71h1.52v1.53H0.76Z" fill="currentColor" stroke-width="1"></path>
+    <path d="M0.76 4.57h1.52V6.1H0.76Z" fill="currentColor" stroke-width="1"></path>
+  </g>
+</svg>

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,25 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { twMerge } from "tailwind-merge";
+
+import Ghost from "@/assets/icons/ghost.svg?react";
+
+export interface AvatarProps extends Omit<ComponentPropsWithoutRef<"img">, "src"> {
+  src?: string | null;
+}
+
+export default function Avatar({ src, alt = "사용자 아바타", className, ...props }: AvatarProps) {
+  return (
+    <div
+      className={twMerge(
+        "flex aspect-square h-max items-center justify-center overflow-hidden rounded-full bg-gray-50",
+        className
+      )}
+    >
+      {src ? (
+        <img src={src} alt={alt} className="h-full w-full object-cover" {...props} />
+      ) : (
+        <Ghost className="text-primary h-3/4 w-3/4" />
+      )}
+    </div>
+  );
+}

--- a/src/features/friends/list/List.tsx
+++ b/src/features/friends/list/List.tsx
@@ -1,6 +1,7 @@
 import { Home, UserMinus2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import Avatar from "@/components/Avatar/Avatar";
 import Button from "@/components/Button/Button";
 import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -62,12 +63,8 @@ export default function List() {
               return (
                 <li key={friend.id}>
                   <div className="flex items-center gap-3 p-2 pl-2 select-none">
-                    <div className="shrink-0">
-                      <img
-                        src={profile.avatar_url ?? ""}
-                        alt="프로필 아바타"
-                        className="h-8 w-8 rounded-full object-cover"
-                      />
+                    <div className="h-8 w-8 shrink-0">
+                      <Avatar src={profile.avatar_url} />
                     </div>
                     <div className="flex min-w-0 flex-1 flex-col">
                       <span className="truncate text-sm font-medium">{profile.nickname}</span>

--- a/src/features/friends/request/Request.tsx
+++ b/src/features/friends/request/Request.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import Avatar from "@/components/Avatar/Avatar";
 import Button from "@/components/Button/Button";
 import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -59,13 +60,8 @@ export default function Request() {
             {requests.map((request) => (
               <li key={request.id}>
                 <div className="flex items-center gap-3 p-2 pl-2 select-none">
-                  <div className="shrink-0">
-                    <img
-                      // TODO: 디폴트 아바타 설정
-                      src={request.requester.avatar_url ?? ""}
-                      alt="프로필 아바타"
-                      className="h-8 w-8 rounded-full object-cover"
-                    />
+                  <div className="h-8 w-8 shrink-0">
+                    <Avatar src={request.requester.avatar_url} />
                   </div>
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className="truncate text-sm font-medium">

--- a/src/features/friends/search/Search.tsx
+++ b/src/features/friends/search/Search.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import Avatar from "@/components/Avatar/Avatar";
 import Button from "@/components/Button/Button";
 import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
 import Input from "@/components/Input/Input";
@@ -75,13 +76,8 @@ export default function Search() {
                 {results.map((Profile) => (
                   <li key={Profile.auth_id}>
                     <div className="flex items-center gap-3 p-2 pl-2 select-none">
-                      <div className="shrink-0">
-                        <img
-                          // TODO: 디폴트 아바타 설정
-                          src={Profile.avatar_url!}
-                          alt="프로필 아바타"
-                          className="h-8 w-8 rounded-full object-cover"
-                        />
+                      <div className="h-8 w-8 shrink-0">
+                        <Avatar src={Profile.avatar_url} />
                       </div>
                       <div className="flex min-w-0 flex-1 flex-col">
                         <span className="truncate text-sm font-medium">{Profile.nickname}</span>

--- a/src/features/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/features/minihome/gallery/GalleryDetailPanel.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, Heart, Send, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
+import Avatar from "@/components/Avatar/Avatar";
 import Button from "@/components/Button/Button";
 import Input from "@/components/Input/Input";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -304,22 +305,13 @@ export default function GalleryDetailPanel({
                 comments.map((comment) => {
                   const nickname = comment.author?.nickname ?? "알 수 없음";
                   const avatar = comment.author?.avatar_url;
-                  const fallbackInitial = nickname.charAt(0);
                   const body = stringifyCommentContent(comment.content);
 
                   return (
                     <div key={comment.id} className="bevel-default bg-text-invert p-3">
                       <div className="flex items-start gap-3">
                         <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
-                          {avatar ? (
-                            <img
-                              src={avatar}
-                              alt={`${nickname} avatar`}
-                              className="h-full w-full object-cover"
-                            />
-                          ) : (
-                            fallbackInitial
-                          )}
+                          <Avatar src={avatar} />
                         </div>
                         <div className="flex-1">
                           <div className="text-muted mb-1 flex items-center justify-between">

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -1,8 +1,9 @@
 import dayjs from "dayjs";
-import { MessageCircle, UserRound, Star } from "lucide-react";
+import { MessageCircle, Star } from "lucide-react";
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { twMerge } from "tailwind-merge";
 
+import Avatar from "@/components/Avatar/Avatar";
 import { useAuthStore } from "@/stores/useAuthStore";
 import type { Database } from "@/types/database.types";
 import type { MiniHomeTabs } from "@/types/minihome.types";
@@ -205,21 +206,12 @@ export default function HomePage({
   };
 
   return (
-    <div className="flex w-[592px] p-3">
+    <div className="flex p-3">
       {/* 왼쪽 프로필 영역 */}
       <div className="mr-3 flex w-1/3 flex-col items-center">
         {/* 프로필 이미지 */}
-        <div className="relative">
-          {avatarUrl ? (
-            <div className="h-32 w-32 overflow-hidden rounded-full border-4 border-[#B2AAEB]">
-              <img className="h-full w-full object-cover" src={avatarUrl} alt="" />
-            </div>
-          ) : (
-            <div className="bevel-default flex h-32 w-32 items-center justify-center rounded-full">
-              <UserRound size={48} color="#B2AAEB" />
-            </div>
-          )}
-        </div>
+
+        <Avatar src={avatarUrl} />
 
         {/* 이름 */}
         <p className="mt-4 text-lg text-[#342b4e]">{nickname}</p>

--- a/src/features/minihome/post/detail/CommentItem.tsx
+++ b/src/features/minihome/post/detail/CommentItem.tsx
@@ -1,8 +1,9 @@
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { Trash, User } from "lucide-react";
+import { Trash } from "lucide-react";
 
+import Avatar from "@/components/Avatar/Avatar";
 import { useAuthUser } from "@/hooks/useAuthUser";
 import type { CommentWithProfile } from "@/types/post.types";
 
@@ -24,13 +25,7 @@ export default function CommentItem({ comment, onDelete, isMyHome }: CommentItem
   return (
     <div className="flex gap-2 border-b border-gray-100 p-2 last:border-none">
       <div className="h-7 w-7 shrink-0 overflow-hidden bg-gray-200">
-        {avatarUrl ? (
-          <img src={avatarUrl} alt={authorName} className="h-full w-full object-cover" />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-gray-500">
-            <User size={16} />
-          </div>
-        )}
+        <Avatar src={avatarUrl} />
       </div>
 
       <div className="flex flex-1 flex-col gap-1">


### PR DESCRIPTION
## 📖 개요

고스트 아이콘 폴백이 포함된 Avatar 컴포넌트 추가 및 리팩토링

## ✅ 관련 이슈

- Close #134 

## 🛠️ 상세 작업 내용

- [x] 사용자 이미지가 없을 때 ghost.svg 아이콘을 표시하는 Avatar 컴포넌트 구현
- [x] ghost.svg 아이콘 에셋 신규 추가
- [x] 이미지 로딩 실패 시 자동으로 폴백 아이콘 표시되도록 처리
- [x] 친구 목록, 친구 요청, 사용자 검색, 갤러리 상세, 홈 화면, 댓글 아이템 등에서 사용하던 <img> 및 폴백 처리 로직을 Avatar 컴포넌트로 일원화
- [x] 중복된 아바타 렌더링 코드를 제거하여 유지보수성과 UI 일관성 개선
- [x] 이미지 로딩 실패 시 Avatar 컴포넌트의 공통 폴백 아이콘이 자동 적용되도록 변경

## 📸 스크린샷

<img width="150" height="138" alt="스크린샷 2025-11-19 23 24 47" src="https://github.com/user-attachments/assets/b8d043a7-1a37-4709-841a-51e3e0ad0163" />

## ⚠️ 주의 사항

_N/A_

## 👥 리뷰 확인 사항

_N/A_
