### PR TITLE
[#139] fix(memo): homepage_owner의 닉네임을 글쓴이로 지정하도록 수정

### DIFF
--- a/src/features/minihome/post/list/PostList.tsx
+++ b/src/features/minihome/post/list/PostList.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 
 import BevelScrollContainer from "@/components/Container/BevelScrollContainer";
-import { useAuthUser } from "@/hooks/useAuthUser";
 import type { PostWithCounts } from "@/types/post.types";
 import supabase from "@/utils/supabase";
 
@@ -15,8 +14,7 @@ interface PostListProps {
 export default function PostList({ onPostClick, ownerId }: PostListProps) {
   const [posts, setPosts] = useState<PostWithCounts[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-
-  const { nickname: authorName } = useAuthUser();
+  const [ownerNickname, setOwnerNickname] = useState<string>("주인장");
 
   useEffect(() => {
     async function fetchPosts() {
@@ -29,7 +27,7 @@ export default function PostList({ onPostClick, ownerId }: PostListProps) {
 
       const { data: homepage, error: homepageError } = await supabase
         .from("homepages")
-        .select("id")
+        .select("id, owner:profiles!homepages_owner_id_fkey(nickname)")
         .eq("owner_id", ownerId)
         .single();
 
@@ -40,6 +38,7 @@ export default function PostList({ onPostClick, ownerId }: PostListProps) {
       }
 
       const homepageIdToFetch = homepage.id;
+      setOwnerNickname(homepage.owner?.nickname ?? "주인장");
 
       const { data, error } = await supabase
         .from("homepage_posts")
@@ -77,7 +76,7 @@ export default function PostList({ onPostClick, ownerId }: PostListProps) {
             <PostItem
               key={post.id}
               post={post}
-              authorName={authorName || "주인장"}
+              authorName={ownerNickname}
               onPostClick={onPostClick}
             />
           ))


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
메모 게시글 리스트가 로그인 사용자 닉네임으로 표시되던 문제를 고치고, 홈 주인의 닉네임을 가져와 보여주도록 수정했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #139 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] useAuthUser를 authorName으로 지정하고 있던 것 제거
- [x] 조인을 통해서 homepage의 Id와 함께 homepage의 onwer_id를 이용해 nickname을 가져오도록 구현
- [x] 조회한 닉네임을 상태로 보관하고 PostItem에 전달

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="927" height="779" alt="image" src="https://github.com/user-attachments/assets/af8fa13d-11b7-48d4-bd2c-035700c98277" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
