### PR TITLE
[#137] fix(minihome): 이미 친구인 사람에게 친구요청 버튼이 노출되는 현상 수정

### DIFF
--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -42,6 +42,7 @@ export default function HomePage({
   const [bio, setBio] = useState<string | null>(null);
 
   const [friendRequested, setFriendRequested] = useState<boolean>(false);
+  const [isFriend, setIsFriend] = useState<boolean>(false);
   const [toggleAnimating, setToggleAnimating] = useState(false);
 
   const [images, setImages] = useState<GalleryImage[]>([]);
@@ -84,15 +85,32 @@ export default function HomePage({
         setBio(profile.bio);
 
         // 친구 신청 여부 정보 가져오기
-        const { count: friendRequestCount, error: friendRequestError } = await supabase
-          .from("friend_requests")
-          .select("*", { count: "exact", head: true })
-          .eq("requester_id", user.id)
-          .eq("addressee_id", ownerId);
-        if (friendRequestError) {
-          console.error("친구 신청 정보 불러오기 실패:", friendRequestError);
+        const { data: friendship, error: friendshipError } = await supabase
+          .from("friends")
+          .select("id")
+          .or(
+            `and(user1_id.eq.${user.id},user2_id.eq.${ownerId}),and(user1_id.eq.${ownerId},user2_id.eq.${user.id})`
+          )
+          .maybeSingle();
+        if (friendshipError) {
+          console.error("친구 관계 정보 불러오기 실패:", friendshipError);
+        }
+        const alreadyFriend = Boolean(friendship);
+        setIsFriend(alreadyFriend);
+
+        if (!alreadyFriend) {
+          const { count: friendRequestCount, error: friendRequestError } = await supabase
+            .from("friend_requests")
+            .select("*", { count: "exact", head: true })
+            .eq("requester_id", user.id)
+            .eq("addressee_id", ownerId);
+          if (friendRequestError) {
+            console.error("친구 신청 정보 불러오기 실패:", friendRequestError);
+          } else {
+            setFriendRequested(friendRequestCount === 1);
+          }
         } else {
-          setFriendRequested(friendRequestCount === 1);
+          setFriendRequested(false);
         }
 
         // 사진첩 정보 가져오기 (최근 8개)
@@ -176,6 +194,10 @@ export default function HomePage({
       console.error("친구신청 상대가 존재하지 않습니다.");
       return;
     }
+    if (isFriend) {
+      console.error("이미 친구 관계입니다.");
+      return;
+    }
 
     setToggleAnimating(true);
 
@@ -222,7 +244,7 @@ export default function HomePage({
         </div>
 
         {/* 친구 신청 버튼 */}
-        {!isMine && (
+        {!isMine && !isFriend && (
           <Button
             type="button"
             className="mt-3 h-16 w-full py-2 text-sm text-[#3f3570] hover:bg-[#e9e0ff]"


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
서로 이미 친구인 경우에도 “친구 신청” 버튼이 노출되던 현상 해결

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #137 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] friends 조회 로직 추가로 isFriend 상태 관리
- [x] 친구 관계일 때 friendRequested 초기화 및 버튼 렌더 조건 !isMine && !isFriend로 변경
- [x] toggleFriendRequest에서 이미 친구면 insert/delete를 수행하지 않도록 구현

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="1090" height="688" alt="image" src="https://github.com/user-attachments/assets/26bb0dcd-135d-4b78-8fc6-6788e0d36bab" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
