### PR TITLE
[#143] fix(memo): 댓글의 프로필 사진 뒤에 회색 배경이 나타나는 현상 수정

### DIFF
--- a/src/features/minihome/gallery/GalleryDetailPanel.tsx
+++ b/src/features/minihome/gallery/GalleryDetailPanel.tsx
@@ -310,9 +310,7 @@ export default function GalleryDetailPanel({
                   return (
                     <div key={comment.id} className="bevel-default bg-text-invert p-3">
                       <div className="flex items-start gap-3">
-                        <div className="bevel-default bg-surface text-primary flex h-10 w-10 items-center justify-center overflow-hidden">
-                          <Avatar src={avatar} />
-                        </div>
+                        <Avatar src={avatar} className="text-primary h-10 w-10 shrink-0" />
                         <div className="flex-1">
                           <div className="text-muted mb-1 flex items-center justify-between">
                             <span className="text-primary">{nickname}</span>

--- a/src/features/minihome/post/detail/CommentItem.tsx
+++ b/src/features/minihome/post/detail/CommentItem.tsx
@@ -24,9 +24,7 @@ export default function CommentItem({ comment, onDelete, isMyHome }: CommentItem
 
   return (
     <div className="flex gap-2 border-b border-gray-100 p-2 last:border-none">
-      <div className="h-7 w-7 shrink-0 overflow-hidden bg-gray-200">
-        <Avatar src={avatarUrl} />
-      </div>
+      <Avatar src={avatarUrl} className="h-7 w-7 shrink-0" />
 
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex justify-between">


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
댓글의 프로필 사진 뒤에 회색 배경이 나타나는 현상 수정
## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #143 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] memo의 avartarUrl을 감싸는 div를 제거
- [x] gallery의 avartarUrl을 감싸는 div를 제거

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="666" height="326" alt="image" src="https://github.com/user-attachments/assets/f2661661-2026-4992-8d8d-d97167effeb1" />
<img width="703" height="306" alt="image" src="https://github.com/user-attachments/assets/ee4771e3-9f61-48ce-a003-3dee833e0f90" />


## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
