### PR TITLE
[#122] refactor(home): 미니홈 메인 전체화면 레이아웃 리팩토링

### DIFF
--- a/src/features/minihome/MiniHome.tsx
+++ b/src/features/minihome/MiniHome.tsx
@@ -51,7 +51,7 @@ export default function MiniHome({ windowId, ownerId, tab = MINIHOME_TABS.home }
           </Tabs.Trigger>
         ))}
       </Tabs.List>
-      <Tabs.Content value={MINIHOME_TABS.home}>
+      <Tabs.Content value={MINIHOME_TABS.home} className="min-h-0 flex-1">
         <Activity>
           <HomePage ownerId={ownerId} setActiveTab={setActiveTab} />
         </Activity>

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -231,7 +231,7 @@ export default function HomePage({
   return (
     <div className="@container flex h-full min-h-0 items-stretch p-3">
       {/* 왼쪽 프로필 영역 */}
-      <div className="mr-3 flex h-full w-1/3 flex-col items-center justify-center">
+      <div className="mr-3 flex h-full w-1/3 flex-col items-center @2xl:justify-center">
         {/* 프로필 이미지 */}
 
         <Avatar src={avatarUrl} className="h-32 w-32 @2xl:h-64 @2xl:w-64" />
@@ -240,7 +240,7 @@ export default function HomePage({
         <p className="mt-4 text-lg text-[#342b4e]">{nickname}</p>
 
         {/* 소개글 */}
-        <div className="bevel-pressed relative mt-4 flex h-2/3 w-full justify-center overflow-y-auto bg-white p-3 text-center text-xs leading-relaxed text-[#2D2640] @2xl:max-h-20">
+        <div className="bevel-pressed relative mt-4 flex h-2/3 w-full justify-center overflow-y-auto bg-white p-3 text-center text-xs leading-relaxed text-[#2D2640] @2xl:h-20">
           <p>{bio}</p>
         </div>
 

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -135,13 +135,13 @@ export default function HomePage({
           setImages(mappedImages);
         }
 
-        // 게시물 정보 가져오기 (최근 3개)
+        // 게시물 정보 가져오기 (최근 6개)
         const { data: postRows, error: postError } = await supabase
           .from("homepage_posts")
           .select("id, title, created_at, visibility")
           .eq("homepage_id", homepage.id)
           .order("created_at", { ascending: false })
-          .limit(3);
+          .limit(6);
 
         if (postError) {
           throw postError;
@@ -316,10 +316,13 @@ export default function HomePage({
           </div>
 
           <ul className="flex flex-1 flex-col text-xs text-[#3d3462]">
-            {posts.map((post) => (
+            {posts.map((post, index) => (
               <li
                 key={post.id}
-                className="mr-3 flex flex-1 items-center justify-between border-b border-[#d7ccef] py-2 last:border-0 hover:bg-[#e9e0ff]"
+                className={twMerge(
+                  "mr-3 flex flex-1 items-center justify-between border-b border-[#d7ccef] py-2 last:border-0 hover:bg-[#e9e0ff]",
+                  index >= 3 && "hidden @2xl:flex"
+                )}
               >
                 <span className="pl-3">{post.title}</span>
                 <div className="flex items-center gap-3 text-[#6b5fa0]">

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -229,9 +229,9 @@ export default function HomePage({
   };
 
   return (
-    <div className="@container flex p-3">
+    <div className="@container flex h-full min-h-0 items-stretch p-3">
       {/* 왼쪽 프로필 영역 */}
-      <div className="mr-3 flex w-1/3 flex-col items-center @2xl:py-40">
+      <div className="mr-3 flex h-full w-1/3 flex-col items-center justify-center">
         {/* 프로필 이미지 */}
 
         <Avatar src={avatarUrl} className="h-32 w-32 @2xl:h-64 @2xl:w-64" />
@@ -268,7 +268,7 @@ export default function HomePage({
       </div>
 
       {/* 오른쪽 콘텐츠 */}
-      <div className="flex w-2/3 flex-col gap-3">
+      <div className="flex h-full w-2/3 flex-col gap-3">
         {/* 사진첩 */}
         <div className="bevel-pressed bg-white p-4 text-[#2D2640]">
           <div className="mb-3 flex items-center justify-between">

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -50,6 +50,7 @@ export default function HomePage({
   const [posts, setPosts] = useState<GalleryPost[]>([]);
 
   useEffect(() => {
+    setPosts([]);
     const fetchHomePage = async () => {
       try {
         if (!user) {

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -231,7 +231,7 @@ export default function HomePage({
   return (
     <div className="@container flex p-3">
       {/* 왼쪽 프로필 영역 */}
-      <div className="mr-3 flex w-1/3 flex-col items-center">
+      <div className="mr-3 flex w-1/3 flex-col items-center @2xl:py-40">
         {/* 프로필 이미지 */}
 
         <Avatar src={avatarUrl} className="h-32 w-32 @2xl:h-64 @2xl:w-64" />
@@ -240,7 +240,7 @@ export default function HomePage({
         <p className="mt-4 text-lg text-[#342b4e]">{nickname}</p>
 
         {/* 소개글 */}
-        <div className="bevel-pressed relative mt-4 flex h-2/3 w-full justify-center bg-white p-4 text-center text-xs leading-relaxed text-[#2D2640]">
+        <div className="bevel-pressed relative mt-4 flex h-2/3 w-full justify-center overflow-y-auto bg-white p-3 text-center text-xs leading-relaxed text-[#2D2640] @2xl:max-h-20">
           <p>{bio}</p>
         </div>
 

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -229,12 +229,12 @@ export default function HomePage({
   };
 
   return (
-    <div className="flex p-3">
+    <div className="@container flex p-3">
       {/* 왼쪽 프로필 영역 */}
       <div className="mr-3 flex w-1/3 flex-col items-center">
         {/* 프로필 이미지 */}
 
-        <Avatar src={avatarUrl} />
+        <Avatar src={avatarUrl} className="h-32 w-32 @2xl:h-64 @2xl:w-64" />
 
         {/* 이름 */}
         <p className="mt-4 text-lg text-[#342b4e]">{nickname}</p>

--- a/src/features/minihome/home/HomePage.tsx
+++ b/src/features/minihome/home/HomePage.tsx
@@ -268,7 +268,7 @@ export default function HomePage({
       </div>
 
       {/* 오른쪽 콘텐츠 */}
-      <div className="flex h-full w-2/3 flex-col gap-3">
+      <div className="scrollbar flex h-full min-h-0 w-2/3 flex-col gap-3 overflow-y-auto pr-2">
         {/* 사진첩 */}
         <div className="bevel-pressed bg-white p-4 text-[#2D2640]">
           <div className="mb-3 flex items-center justify-between">


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 탭을 전체 화면으로 확장했을 때 왼쪽 영역의 프로필 이미지가 커지고 바이오가 작아져서 중앙에 오도록 하였습니다. 
높이가 낮아졌을 때 오른쪽 콘텐츠 영역이 가려지지 않도록 레이아웃과 스크롤을 손봤습니다.

- 최근 게시물은 항상 6개까지 받아 두고, 컨테이너 브레이크포인트(@2xl) 기준으로 3/6개가 토글되도록 Tailwind 유틸을 적용했습니다.

## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #122 
- Close #125 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] 우측 영역을 scrollbar + overflow-y-auto 구성으로 바꿔 창 높이 축소 시에도 스크롤로 모든 콘텐츠 확인 가능하게 변경
- [x] 좌측 프로필 영역을 h-full + justify-center로 세로 중앙 정렬 유지
- [x] 최근 게시물 쿼리를 .limit(6)으로 고정하고, 4번째 이후 항목에 hidden @2xl:flex 클래스를 적용해 반응형 노출 제어
- [x] #125 버그 수정

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="2040" height="1233" alt="image" src="https://github.com/user-attachments/assets/d364f3bb-3327-4955-bc4a-89a879eb6f01" />
<img width="2565" height="1187" alt="image" src="https://github.com/user-attachments/assets/c835bfd1-5de6-4c00-9b7f-5318f76ce178" />


## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->
MiniHome.tsx에서 MINIHOME_TABS.home에 대해서 className="min-h-0 flex-1" 적용하였습니다.
## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
