### PR TITLE
fix(home): 프로필 사진이 가로로 눌리지 않게 수정

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -11,7 +11,7 @@ export default function Avatar({ src, alt = "사용자 아바타", className, ..
   return (
     <div
       className={twMerge(
-        "flex aspect-square h-max items-center justify-center overflow-hidden rounded-full bg-gray-50",
+        "flex aspect-square h-max min-w-[128px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-50",
         className
       )}
     >


### PR DESCRIPTION
<!--
PR 제목 규칙
[#이슈번호] type(scope): 한 줄 요약
[#] type(scope):
-->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
프로필 사진이 가로로 눌리지 않게 수정
## ✅ 관련 이슈

<!-- Close #이슈번호 형태로 연결할 이슈를 작성해주세요 -->
<!-- 없으면
_N/A_
-->

- Close #

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 체크박스로 작성해주세요 -->

- [x] avatar 래퍼에 min-w-[128px] shrink-0 설정

## 📸 스크린샷

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->
<!-- 없으면
_N/A_
-->
<img width="768" height="621" alt="image" src="https://github.com/user-attachments/assets/9c88e5bf-75f0-463d-8980-8b71b60a271a" />

## ⚠️ 주의 사항

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
<!-- 없으면
_N/A_
-->

## 👥 리뷰 확인 사항

<!--
리뷰어가 집중해서 봐야 하는 부분이 있다면 명시하세요.
예시:
- 타입 정의나 제네릭 사용이 적절한지 확인 부탁드립니다.
-->
